### PR TITLE
Removing Preview specification on VS Tooling template

### DIFF
--- a/e2etest/ZumoE2EServerApp.csproj
+++ b/e2etest/ZumoE2EServerApp.csproj
@@ -54,39 +54,39 @@
       <HintPath>packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile.Server, Version=0.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Azure.Mobile.Server.0.3.34.0\lib\net45\Microsoft.Azure.Mobile.Server.dll</HintPath>
+      <HintPath>packages\Microsoft.Azure.Mobile.Server.0.3.36.0\lib\net45\Microsoft.Azure.Mobile.Server.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile.Server.Authentication, Version=0.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Azure.Mobile.Server.Authentication.0.3.34.0\lib\net45\Microsoft.Azure.Mobile.Server.Authentication.dll</HintPath>
+      <HintPath>packages\Microsoft.Azure.Mobile.Server.Authentication.0.3.36.0\lib\net45\Microsoft.Azure.Mobile.Server.Authentication.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile.Server.CrossDomain, Version=0.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Azure.Mobile.Server.CrossDomain.0.3.34.0\lib\net45\Microsoft.Azure.Mobile.Server.CrossDomain.dll</HintPath>
+      <HintPath>packages\Microsoft.Azure.Mobile.Server.CrossDomain.0.3.36.0\lib\net45\Microsoft.Azure.Mobile.Server.CrossDomain.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile.Server.Entity, Version=0.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Azure.Mobile.Server.Entity.0.3.34.0\lib\net45\Microsoft.Azure.Mobile.Server.Entity.dll</HintPath>
+      <HintPath>packages\Microsoft.Azure.Mobile.Server.Entity.0.3.36.0\lib\net45\Microsoft.Azure.Mobile.Server.Entity.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile.Server.Home, Version=0.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Azure.Mobile.Server.Home.0.3.34.0\lib\net45\Microsoft.Azure.Mobile.Server.Home.dll</HintPath>
+      <HintPath>packages\Microsoft.Azure.Mobile.Server.Home.0.3.36.0\lib\net45\Microsoft.Azure.Mobile.Server.Home.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile.Server.Login, Version=0.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Azure.Mobile.Server.Login.0.3.34.0\lib\net45\Microsoft.Azure.Mobile.Server.Login.dll</HintPath>
+      <HintPath>packages\Microsoft.Azure.Mobile.Server.Login.0.3.36.0\lib\net45\Microsoft.Azure.Mobile.Server.Login.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile.Server.Notifications, Version=0.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Azure.Mobile.Server.Notifications.0.3.34.0\lib\net45\Microsoft.Azure.Mobile.Server.Notifications.dll</HintPath>
+      <HintPath>packages\Microsoft.Azure.Mobile.Server.Notifications.0.3.36.0\lib\net45\Microsoft.Azure.Mobile.Server.Notifications.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile.Server.Quickstart, Version=0.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Azure.Mobile.Server.Quickstart.0.3.34.0\lib\net45\Microsoft.Azure.Mobile.Server.Quickstart.dll</HintPath>
+      <HintPath>packages\Microsoft.Azure.Mobile.Server.Quickstart.0.3.36.0\lib\net45\Microsoft.Azure.Mobile.Server.Quickstart.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Mobile.Server.Tables, Version=0.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Azure.Mobile.Server.Tables.0.3.34.0\lib\net45\Microsoft.Azure.Mobile.Server.Tables.dll</HintPath>
+      <HintPath>packages\Microsoft.Azure.Mobile.Server.Tables.0.3.36.0\lib\net45\Microsoft.Azure.Mobile.Server.Tables.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.NotificationHubs">

--- a/e2etest/packages.config
+++ b/e2etest/packages.config
@@ -9,15 +9,15 @@
   <package id="Microsoft.AspNet.WebApi.OData" version="5.5.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Tracing" version="5.2.3" targetFramework="net45" />
-  <package id="Microsoft.Azure.Mobile.Server" version="0.3.34.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.Mobile.Server.Authentication" version="0.3.34.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.Mobile.Server.CrossDomain" version="0.3.34.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.Mobile.Server.Entity" version="0.3.34.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.Mobile.Server.Home" version="0.3.34.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.Mobile.Server.Login" version="0.3.34.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.Mobile.Server.Notifications" version="0.3.34.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.Mobile.Server.Quickstart" version="0.3.34.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.Mobile.Server.Tables" version="0.3.34.0" targetFramework="net45" />
+  <package id="Microsoft.Azure.Mobile.Server" version="0.3.36.0" targetFramework="net45" />
+  <package id="Microsoft.Azure.Mobile.Server.Authentication" version="0.3.36.0" targetFramework="net45" />
+  <package id="Microsoft.Azure.Mobile.Server.CrossDomain" version="0.3.36.0" targetFramework="net45" />
+  <package id="Microsoft.Azure.Mobile.Server.Entity" version="0.3.36.0" targetFramework="net45" />
+  <package id="Microsoft.Azure.Mobile.Server.Home" version="0.3.36.0" targetFramework="net45" />
+  <package id="Microsoft.Azure.Mobile.Server.Login" version="0.3.36.0" targetFramework="net45" />
+  <package id="Microsoft.Azure.Mobile.Server.Notifications" version="0.3.36.0" targetFramework="net45" />
+  <package id="Microsoft.Azure.Mobile.Server.Quickstart" version="0.3.36.0" targetFramework="net45" />
+  <package id="Microsoft.Azure.Mobile.Server.Tables" version="0.3.36.0" targetFramework="net45" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.2" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net45" />

--- a/templates/ProjectTemplate/CSharp/1033/Templates.xml
+++ b/templates/ProjectTemplate/CSharp/1033/Templates.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <TemplateDefinition Name="Microsoft Azure Mobile App" Order="2005">
     <UI>
-        <Template Name="Azure Mobile App (Preview)" BaseTemplateID="Microsoft.WAP.CSharp.MobileApp.v1.0" Order="3000">
+        <Template Name="Azure Mobile App" BaseTemplateID="Microsoft.WAP.CSharp.MobileApp.v1.0" Order="3000">
             <Icon>CSProject.ico</Icon>
             <PreviewImage>CSProject.ico</PreviewImage>
             <Summary>A project template for creating an ASP.NET Web API-based mobile backend for a Microsoft Azure Mobile App.</Summary>

--- a/templates/ProjectTemplate/VisualBasic/1033/Templates.xml
+++ b/templates/ProjectTemplate/VisualBasic/1033/Templates.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <TemplateDefinition Name="Microsoft Azure Mobile App" Order="2005">
     <UI>
-        <Template Name="Azure Mobile App (Preview)" BaseTemplateID="Microsoft.WAP.CSharp.MobileApp.v1.0" Order="3000">
+        <Template Name="Azure Mobile App" BaseTemplateID="Microsoft.WAP.CSharp.MobileApp.v1.0" Order="3000">
             <Icon>VBProject.ico</Icon>
             <PreviewImage>VBProject.ico</PreviewImage>
             <Summary>A project template for creating an ASP.NET Web API-based mobile backend for a Microsoft Azure Mobile App.</Summary>


### PR DESCRIPTION
The version number changes on the different packages DOES NOT need to be merged because those are being removed, please ignore those changes.  Just want the "(preview)" removal in there.