### PR TITLE
Obsolete PushClient.SendAsync

### DIFF
--- a/src/Microsoft.Azure.Mobile.Server.Notifications/PushClient.cs
+++ b/src/Microsoft.Azure.Mobile.Server.Notifications/PushClient.cs
@@ -143,6 +143,8 @@ namespace Microsoft.Azure.Mobile.Server.Notifications
         /// <see cref="ApplePushMessage"/>, or <see cref="TemplatePushMessage"/>.</param>
         /// <param name="tags">The set of tags to use for this notification.</param>
         /// <returns>A <see cref="Task{T}"/> representing the notification send operation.</returns>
+        /// <remarks>This method is obsolete. You should use the HubClient.SendNotificationAsync() method instead.</remarks>
+        [Obsolete]
         public virtual Task<NotificationOutcome> SendAsync(IPushMessage message, IEnumerable<string> tags)
         {
             if (message == null)

--- a/test/Microsoft.Azure.Mobile.Server.Notifications.Test/Notifications/PushClientTests.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Notifications.Test/Notifications/PushClientTests.cs
@@ -196,26 +196,5 @@ namespace Microsoft.Azure.Mobile.Server.Notifications
             // Assert
             this.clientMock.Verify();
         }
-
-        [Theory]
-        [MemberData("PushMessages")]
-        public void SendAsync_WithTag_SendsValidNotification(IPushMessage message, Type expected)
-        {
-            // Arrange
-            List<string> tags = new List<string>();
-            this.clientMock.Protected()
-                .Setup("SendNotificationAsync", ItExpr.IsAny<Notification>(), tags)
-                .Callback((Notification notification, IEnumerable<string> t) =>
-                {
-                    Assert.IsType(expected, notification);
-                })
-                .Verifiable();
-
-            // Act
-            this.client.SendAsync(message, tags);
-
-            // Assert
-            this.clientMock.Verify();
-        }
     }
 }


### PR DESCRIPTION
PushClient was never to surface this API.  Instead, customers should be using the NotificationHubClient directly.

I also had to remove the test for SendAsync, since it's no longer relevant.

https://github.com/Azure/azure-mobile-apps-net-server/issues/53
