### PR TITLE
improving configurability with IMobileAppControllerConfigProvider

### DIFF
--- a/e2etest/DataObjects/ParamsTestTableEntity.cs
+++ b/e2etest/DataObjects/ParamsTestTableEntity.cs
@@ -2,12 +2,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // ----------------------------------------------------------------------------
 
-using Microsoft.Azure.Mobile.Server.Tables;
 using System;
+using Microsoft.Azure.Mobile.Server.Tables;
 
 namespace ZumoE2EServerApp.DataObjects
 {
-    public class ParamsTestTableEntity : ITableData
+    public sealed class ParamsTestTableEntity : ITableData
     {
         public int Id { get; set; }
         public string Parameters { get; set; }

--- a/samples/SampleApp/SampleApp.csproj
+++ b/samples/SampleApp/SampleApp.csproj
@@ -35,7 +35,7 @@
     <DocumentationFile>bin\Local.XML</DocumentationFile>
     <NoWarn>1591,0618</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <CodeAnalysisRuleSet>..\..\src\Src.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/Microsoft.Azure.Mobile.Server.Tables/Config/MobileAppTableConfiguration.cs
+++ b/src/Microsoft.Azure.Mobile.Server.Tables/Config/MobileAppTableConfiguration.cs
@@ -7,12 +7,15 @@ using Microsoft.Azure.Mobile.Server.Config;
 namespace Microsoft.Azure.Mobile.Server.Tables.Config
 {
     /// <summary>
+    /// Provides configuration methods for Mobile App controllers that derive from <see cref="TableController"/>.
     /// </summary>
     public class MobileAppTableConfiguration : AppConfiguration
     {
         /// <summary>
+        /// Maps all controllers that derive from <see cref="TableController" /> to the
+        /// route template "tables/{controller}/{id}".
         /// </summary>
-        /// <returns></returns>
+        /// <returns>The current <see cref="MobileAppTableConfiguration"/>.</returns>
         public MobileAppTableConfiguration MapTableControllers()
         {
             this.RegisterConfigProvider(new MapTableControllersExtensionConfigProvider());

--- a/src/Microsoft.Azure.Mobile.Server.Tables/Extensions/TableMobileAppOptionsExtensions.cs
+++ b/src/Microsoft.Azure.Mobile.Server.Tables/Extensions/TableMobileAppOptionsExtensions.cs
@@ -3,6 +3,7 @@
 // ----------------------------------------------------------------------------
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Azure.Mobile.Server.Tables;
 using Microsoft.Azure.Mobile.Server.Tables.Config;
@@ -10,14 +11,18 @@ using Microsoft.Azure.Mobile.Server.Tables.Config;
 namespace Microsoft.Azure.Mobile.Server.Config
 {
     /// <summary>
+    /// Extension methods for <see cref="MobileAppConfiguration"/>.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static class TableMobileAppOptionsExtensions
     {
         /// <summary>
+        /// Registers the specified <see cref="ITableControllerConfigProvider" /> with the <see cref="System.Web.Http.HttpConfiguration"/>.
+        /// Use this to override the default <see cref="TableController"/> configuration.
         /// </summary>
-        /// <param name="options"></param>
-        /// <param name="tableConfigProvider"></param>
-        /// <returns></returns>
+        /// <param name="options">The configuration object.</param>
+        /// <param name="tableConfigProvider">The provider to register.</param>
+        /// <returns>The current <see cref="Microsoft.Azure.Mobile.Server.Config.MobileAppConfiguration"/>.</returns>
         [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters", Justification = "We only want this extension to apply to MobileAppConfiguration, not just any AppConfiguration")]
         public static MobileAppConfiguration WithTableControllerConfigProvider(this MobileAppConfiguration options, ITableControllerConfigProvider tableConfigProvider)
         {
@@ -36,9 +41,10 @@ namespace Microsoft.Azure.Mobile.Server.Config
         }
 
         /// <summary>
+        /// Registers a new <see cref="MobileAppTableConfiguration" /> that maps a route for all controllers that derive from <see cref="TableController"/>.
         /// </summary>
-        /// <param name="config"></param>
-        /// <returns></returns>
+        /// <param name="config">The configuration object.</param>
+        /// <returns>The current <see cref="Microsoft.Azure.Mobile.Server.Config.MobileAppConfiguration"/>.</returns>
         public static MobileAppConfiguration AddTables(this MobileAppConfiguration config)
         {
             MobileAppTableConfiguration tableConfig = new MobileAppTableConfiguration().MapTableControllers();
@@ -47,10 +53,11 @@ namespace Microsoft.Azure.Mobile.Server.Config
         }
 
         /// <summary>
+        /// Registers the specified <see cref="MobileAppTableConfiguration"/>.
         /// </summary>
-        /// <param name="config"></param>
+        /// <param name="config">The configuration object.</param>
         /// <param name="tableConfig"></param>
-        /// <returns></returns>
+        /// <returns>The current <see cref="Microsoft.Azure.Mobile.Server.Config.MobileAppConfiguration"/>.</returns>
         [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters", Justification = "We only want this extension to apply to MobileAppConfiguration, not just any AppConfiguration")]
         public static MobileAppConfiguration AddTables(this MobileAppConfiguration config, MobileAppTableConfiguration tableConfig)
         {

--- a/src/Microsoft.Azure.Mobile.Server.Tables/Tables/TableControllerConfigAttribute.cs
+++ b/src/Microsoft.Azure.Mobile.Server.Tables/Tables/TableControllerConfigAttribute.cs
@@ -3,6 +3,7 @@
 // ----------------------------------------------------------------------------
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Web.Http;
 using System.Web.Http.Controllers;
 using Microsoft.Azure.Mobile.Server.Config;
@@ -13,25 +14,21 @@ namespace Microsoft.Azure.Mobile.Server.Tables
     /// Performs configuration customizations for <see cref="TableController{TData}"/> derived controllers.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class)]
-    public sealed class TableControllerConfigAttribute : MobileAppControllerAttribute, IControllerConfiguration
+    public sealed class TableControllerConfigAttribute : MobileAppActionFilterAttribute, IControllerConfiguration
     {
         /// <inheritdoc />
-        public override void Initialize(HttpControllerSettings controllerSettings, HttpControllerDescriptor controllerDescriptor)
+        public void Initialize(HttpControllerSettings controllerSettings, HttpControllerDescriptor controllerDescriptor)
         {
             if (controllerDescriptor == null)
             {
                 throw new ArgumentNullException("controllerDescriptor");
             }
 
-            base.Initialize(controllerSettings, controllerDescriptor);
-
-            ITableControllerConfigProvider configurationProvider = controllerDescriptor.Configuration.GetTableControllerConfigProvider();
-            if (configurationProvider == null)
-            {
-                configurationProvider = new TableControllerConfigProvider();
-            }
-
+            IMobileAppControllerConfigProvider configurationProvider = controllerDescriptor.Configuration.GetMobileAppControllerConfigProvider();
             configurationProvider.Configure(controllerSettings, controllerDescriptor);
+
+            ITableControllerConfigProvider tableConfigurationProvider = controllerDescriptor.Configuration.GetTableControllerConfigProvider();
+            tableConfigurationProvider.Configure(controllerSettings, controllerDescriptor);
         }
     }
 }

--- a/src/Microsoft.Azure.Mobile.Server.Tables/Tables/TableControllerConfigProvider.cs
+++ b/src/Microsoft.Azure.Mobile.Server.Tables/Tables/TableControllerConfigProvider.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Mobile.Server.Tables
     public class TableControllerConfigProvider : ITableControllerConfigProvider
     {
         /// <inheritdoc />
-        public void Configure(HttpControllerSettings controllerSettings, HttpControllerDescriptor controllerDescriptor)
+        public virtual void Configure(HttpControllerSettings controllerSettings, HttpControllerDescriptor controllerDescriptor)
         {
             if (controllerSettings == null)
             {

--- a/src/Microsoft.Azure.Mobile.Server/Config/IMobileAppControllerConfigProvider.cs
+++ b/src/Microsoft.Azure.Mobile.Server/Config/IMobileAppControllerConfigProvider.cs
@@ -4,16 +4,16 @@
 
 using System.Web.Http.Controllers;
 
-namespace Microsoft.Azure.Mobile.Server.Tables
+namespace Microsoft.Azure.Mobile.Server.Config
 {
     /// <summary>
-    /// Provides an abstraction for performing configuration customizations for <see cref="TableController{TData}"/> derived
-    /// controllers. An implementation can be registered via the <see cref="System.Web.Http.HttpConfiguration"/>.
+    /// Provides an abstraction for performing configuration customizations for controllers with the <see cref="MobileAppControllerAttribute"/>.
+    /// An implementation can be registered via the <see cref="System.Web.Http.HttpConfiguration"/>.
     /// </summary>
-    public interface ITableControllerConfigProvider
+    public interface IMobileAppControllerConfigProvider
     {
         /// <summary>
-        /// Configures the settings specific for controllers of type <see cref="TableController{TData}"/>.
+        /// Configures the settings specific for controllers using <see cref="MobileAppControllerAttribute"/>.
         /// </summary>
         /// <param name="controllerSettings">The <see cref="HttpControllerSettings"/> for this controller type.</param>
         /// <param name="controllerDescriptor">The <see cref="HttpControllerDescriptor"/> for this controller type.</param>

--- a/src/Microsoft.Azure.Mobile.Server/Config/MobileAppActionFilterAttribute.cs
+++ b/src/Microsoft.Azure.Mobile.Server/Config/MobileAppActionFilterAttribute.cs
@@ -1,0 +1,143 @@
+﻿// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Net.Http;
+using System.Text.RegularExpressions;
+using System.Web.Http;
+using System.Web.Http.Controllers;
+using System.Web.Http.Filters;
+using System.Web.Http.Tracing;
+using Microsoft.Azure.Mobile.Server.Cache;
+using Microsoft.Azure.Mobile.Server.Properties;
+
+namespace Microsoft.Azure.Mobile.Server.Config
+{
+    /// <summary>
+    /// Provides the headers and cache policy behavior required for Mobile App clients.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, Inherited = true, AllowMultiple = true)]
+    [SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes", Justification = "We want to derive from this.")]
+    public class MobileAppActionFilterAttribute : ActionFilterAttribute
+    {
+        internal const string VersionHeaderName = "x-zumo-server-version";
+        internal const string VersionHeaderValuePrefix = "net-";
+        internal const string ApiVersionName = "ZUMO-API-VERSION";
+
+        // Eventually we may need to capture & compare: @"(\d)[.](\d)[.](\d) instead
+        internal const string ApiVersionRegex = @"^2[.]0[.]\d+$";
+
+        internal const string ForwardLinkURL = "http://go.microsoft.com/fwlink/?LinkId=690568#2.0.0";
+
+        /// <inheritdoc />
+        public override void OnActionExecuting(HttpActionContext actionContext)
+        {
+            if (actionContext == null)
+            {
+                throw new ArgumentNullException("actionContext");
+            }
+            HttpRequestMessage request = actionContext.Request;
+            if (request == null)
+            {
+                throw new ArgumentException("ActionContext.Request");
+            }
+
+            var settingsProvider = actionContext.ControllerContext.Configuration.GetMobileAppSettingsProvider();
+
+            if (!settingsProvider.GetMobileAppSettings().SkipVersionCheck)
+            {
+                string version = request.GetQueryNameValuePairs()
+                                            .Where(p => p.Key.Equals(ApiVersionName, StringComparison.OrdinalIgnoreCase))
+                                            .Select(p => p.Value)
+                                            .FirstOrDefault();
+
+                if (version == null)
+                {
+                    version = request.GetHeaderOrDefault(ApiVersionName);
+                }
+
+                if (version != null)
+                {
+                    var pattern = new Regex(ApiVersionRegex);
+                    if (!pattern.IsMatch(version))
+                    {
+                        actionContext.Response = request.CreateBadRequestResponse(RResources.Version_Unsupported.FormatForUser("2.0.0", ForwardLinkURL));
+                        return;
+                    }
+                }
+                else
+                {
+                    actionContext.Response = request.CreateBadRequestResponse(RResources.Version_Required.FormatForUser("2.0.0", ForwardLinkURL));
+                    return;
+                }
+            }
+
+            base.OnActionExecuting(actionContext);
+        }
+
+        /// <inheritdoc />
+        public override void OnActionExecuted(HttpActionExecutedContext actionExecutedContext)
+        {
+            if (actionExecutedContext == null)
+            {
+                throw new ArgumentNullException("actionExecutedContext");
+            }
+
+            HttpConfiguration config = actionExecutedContext.ActionContext.ControllerContext.Configuration;
+            ICachePolicyProvider provider = config.GetCachePolicyProvider();
+            HttpRequestMessage request = actionExecutedContext.Request;
+            HttpResponseMessage response = actionExecutedContext.Response;
+
+            SetCachePolicy(provider, request, response, config.Services.GetTraceWriter());
+            SetVersionHeader(response);
+        }
+
+        private static void SetCachePolicy(ICachePolicyProvider provider, HttpRequestMessage request, HttpResponseMessage response, ITraceWriter tracer)
+        {
+            if (provider != null && response != null && IsCacheableMethod(request.Method) && !HasCachingHeaders(response))
+            {
+                try
+                {
+                    provider.SetCachePolicy(response);
+                }
+                catch (Exception ex)
+                {
+                    string msg = RResources.CachePolicy_BadProvider.FormatForUser(provider.GetType().Name, ex.Message);
+                    tracer.Error(msg, ex, request, LogCategories.MessageHandlers);
+                }
+            }
+        }
+
+        internal static void SetVersionHeader(HttpResponseMessage response)
+        {
+            if (response != null)
+            {
+                string version = AssemblyUtils.AssemblyFileVersion;
+                response.Headers.Add(VersionHeaderName, VersionHeaderValuePrefix + version);
+            }
+        }
+
+        internal static bool IsCacheableMethod(HttpMethod method)
+        {
+            return method != null && (method == HttpMethod.Get || method == HttpMethod.Head);
+        }
+
+        /// <summary>
+        /// Determines whether caching headers have already been applied. We look for "Cache-Control" and "Expires".
+        /// We don't look for just "Pragma" as this is not a reliable header for control caching.
+        /// </summary>
+        /// <param name="response">The <see cref="HttpResponseMessage"/>.</param>
+        /// <returns><c>true</c> if either "Cache-Control" or "Expires" has been set.</returns>
+        internal static bool HasCachingHeaders(HttpResponseMessage response)
+        {
+            IEnumerable<string> expires;
+            return response != null
+                && (response.Headers.CacheControl != null
+                || (response.Content != null && response.Content.Headers.TryGetValues("Expires", out expires)));
+        }
+    }
+}

--- a/src/Microsoft.Azure.Mobile.Server/Config/MobileAppConfiguration.cs
+++ b/src/Microsoft.Azure.Mobile.Server/Config/MobileAppConfiguration.cs
@@ -15,15 +15,8 @@ namespace Microsoft.Azure.Mobile.Server.Config
     /// </summary>
     public class MobileAppConfiguration : AppConfiguration
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Microsoft.Azure.Mobile.Server.Config.MobileAppConfiguration" /> class.
-        /// </summary>
-        public MobileAppConfiguration()
-        {
-            this.EnableApiControllers = false;
-        }
-
-        private bool EnableApiControllers { get; set; }
+        private bool enableApiControllers = false;
+        private IMobileAppControllerConfigProvider configProvider = new MobileAppControllerConfigProvider();
 
         /// <inheritdoc />
         public override void ApplyTo(HttpConfiguration config)
@@ -34,10 +27,11 @@ namespace Microsoft.Azure.Mobile.Server.Config
             }
 
             config.SetMobileAppConfiguration(this);
+            config.SetMobileAppControllerConfigProvider(this.configProvider);
 
             base.ApplyTo(config);
 
-            if (this.EnableApiControllers)
+            if (this.enableApiControllers)
             {
                 MapApiControllers(config);
             }
@@ -50,7 +44,24 @@ namespace Microsoft.Azure.Mobile.Server.Config
         /// <returns>The current <see cref="Microsoft.Azure.Mobile.Server.Config.MobileAppConfiguration"/>.</returns>
         public MobileAppConfiguration MapApiControllers()
         {
-            this.EnableApiControllers = true;
+            this.enableApiControllers = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Registers the specified <see cref="IMobileAppControllerConfigProvider" /> with the <see cref="HttpConfiguration"/>.
+        /// Use this to override the default controller configuration.
+        /// </summary>
+        /// <param name="provider">The provider to register.</param>
+        /// <returns>The current <see cref="Microsoft.Azure.Mobile.Server.Config.MobileAppConfiguration"/>.</returns>
+        public MobileAppConfiguration WithMobileAppControllerConfigProvider(IMobileAppControllerConfigProvider provider)
+        {
+            if (provider == null)
+            {
+                throw new ArgumentNullException("provider");
+            }
+
+            this.configProvider = provider;
             return this;
         }
 

--- a/src/Microsoft.Azure.Mobile.Server/Config/MobileAppControllerAttribute.cs
+++ b/src/Microsoft.Azure.Mobile.Server/Config/MobileAppControllerAttribute.cs
@@ -3,180 +3,31 @@
 // ----------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.Linq;
-using System.Net.Http;
-using System.Net.Http.Formatting;
-using System.Text.RegularExpressions;
 using System.Web.Http;
 using System.Web.Http.Controllers;
-using System.Web.Http.Filters;
-using System.Web.Http.Tracing;
-using Microsoft.Azure.Mobile.Server.Cache;
-using Microsoft.Azure.Mobile.Server.Properties;
-using Microsoft.Azure.Mobile.Server.Serialization;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace Microsoft.Azure.Mobile.Server.Config
 {
     /// <summary>
     /// Specifies that this controller is for use by an Azure Mobile App client. Specific settings
-    /// are applied to ensure the controller interacts correctly with the client.
+    /// are applied to ensure the controller interacts correctly with the client. To customize these settings,
+    /// register an <see cref="IMobileAppControllerConfigProvider"/> with the current <see cref="HttpConfiguration"/>.
     /// </summary>
-    [SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes", Justification = "We need to derive from this and override Initialize")]
     [AttributeUsage(AttributeTargets.Class)]
-    public class MobileAppControllerAttribute : ActionFilterAttribute, IControllerConfiguration
+    [SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes", Justification = "We want to derive from this.")]
+    public class MobileAppControllerAttribute : MobileAppActionFilterAttribute, IControllerConfiguration
     {
-        internal const string VersionHeaderName = "x-zumo-server-version";
-        internal const string VersionHeaderValuePrefix = "net-";
-        internal const string ApiVersionName = "ZUMO-API-VERSION";
-
-        // Eventually we may need to capture & compare: @"(\d)[.](\d)[.](\d) instead
-        internal const string ApiVersionRegex = @"^2[.]0[.]\d+$";
-
-        internal const string ForwardLinkURL = "http://go.microsoft.com/fwlink/?LinkId=690568#2.0.0";
-
         /// <inheritdoc />
         public virtual void Initialize(HttpControllerSettings controllerSettings, HttpControllerDescriptor controllerDescriptor)
         {
-            if (controllerSettings == null)
+            if (controllerDescriptor == null)
             {
-                throw new ArgumentNullException("controllerSettings");
+                throw new ArgumentNullException("controllerDescriptor");
             }
 
-            JsonMediaTypeFormatter jsonFormatter = new JsonMediaTypeFormatter();
-            JsonSerializerSettings serializerSettings = jsonFormatter.SerializerSettings;
-
-            // Set up date/time format to be ISO 8601 but with 3 digits and "Z" as UTC time indicator. This format
-            // is the JS-valid format accepted by most JS clients.
-            IsoDateTimeConverter dateTimeConverter = new IsoDateTimeConverter()
-            {
-                Culture = CultureInfo.InvariantCulture,
-                DateTimeFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFZ",
-                DateTimeStyles = DateTimeStyles.AdjustToUniversal
-            };
-
-            // Ignoring default values while serializing was affecting offline scenarios as client sdk looks at first object in a batch for the properties.
-            // If first row in the server response did not include columns with default values, client sdk ignores these columns for the rest of the rows
-            serializerSettings.DefaultValueHandling = DefaultValueHandling.Include;
-            serializerSettings.NullValueHandling = NullValueHandling.Include;
-            serializerSettings.Converters.Add(new StringEnumConverter());
-            serializerSettings.Converters.Add(dateTimeConverter);
-            serializerSettings.MissingMemberHandling = MissingMemberHandling.Error;
-            serializerSettings.CheckAdditionalContent = true;
-            serializerSettings.ContractResolver = new ServiceContractResolver(jsonFormatter);
-            controllerSettings.Formatters.Remove(controllerSettings.Formatters.JsonFormatter);
-            controllerSettings.Formatters.Insert(0, jsonFormatter);
-        }
-
-        /// <inheritdoc />
-        public override void OnActionExecuting(HttpActionContext actionContext)
-        {
-            if (actionContext == null)
-            {
-                throw new ArgumentNullException("actionContext");
-            }
-            HttpRequestMessage request = actionContext.Request;
-            if (request == null)
-            {
-                throw new ArgumentException("ActionContext.Request");
-            }
-
-            var settingsProvider = actionContext.ControllerContext.Configuration.GetMobileAppSettingsProvider();
-
-            if (!settingsProvider.GetMobileAppSettings().SkipVersionCheck)
-            {
-                string version = request.GetQueryNameValuePairs()
-                                            .Where(p => p.Key.Equals(ApiVersionName, StringComparison.OrdinalIgnoreCase))
-                                            .Select(p => p.Value)
-                                            .FirstOrDefault();
-
-                if (version == null)
-                {
-                    version = request.GetHeaderOrDefault(ApiVersionName);
-                }
-
-                if (version != null)
-                {
-                    var pattern = new Regex(ApiVersionRegex);
-                    if (!pattern.IsMatch(version))
-                    {
-                        actionContext.Response = request.CreateBadRequestResponse(RResources.Version_Unsupported.FormatForUser("2.0.0", ForwardLinkURL));
-                        return;
-                    }
-                }
-                else
-                {
-                    actionContext.Response = request.CreateBadRequestResponse(RResources.Version_Required.FormatForUser("2.0.0", ForwardLinkURL));
-                    return;
-                }
-            }
-
-            base.OnActionExecuting(actionContext);
-        }
-
-        /// <inheritdoc />
-        public override void OnActionExecuted(HttpActionExecutedContext actionExecutedContext)
-        {
-            if (actionExecutedContext == null)
-            {
-                throw new ArgumentNullException("actionExecutedContext");
-            }
-
-            HttpConfiguration config = actionExecutedContext.ActionContext.ControllerContext.Configuration;
-            ICachePolicyProvider provider = config.GetCachePolicyProvider();
-            HttpRequestMessage request = actionExecutedContext.Request;
-            HttpResponseMessage response = actionExecutedContext.Response;
-
-            SetCachePolicy(provider, request, response, config.Services.GetTraceWriter());
-            SetVersionHeader(response);
-        }
-
-        private static void SetCachePolicy(ICachePolicyProvider provider, HttpRequestMessage request, HttpResponseMessage response, ITraceWriter tracer)
-        {
-            if (provider != null && response != null && IsCacheableMethod(request.Method) && !HasCachingHeaders(response))
-            {
-                try
-                {
-                    provider.SetCachePolicy(response);
-                }
-                catch (Exception ex)
-                {
-                    string msg = RResources.CachePolicy_BadProvider.FormatForUser(provider.GetType().Name, ex.Message);
-                    tracer.Error(msg, ex, request, LogCategories.MessageHandlers);
-                }
-            }
-        }
-
-        internal static void SetVersionHeader(HttpResponseMessage response)
-        {
-            if (response != null)
-            {
-                string version = AssemblyUtils.AssemblyFileVersion;
-                response.Headers.Add(VersionHeaderName, VersionHeaderValuePrefix + version);
-            }
-        }
-
-        internal static bool IsCacheableMethod(HttpMethod method)
-        {
-            return method != null && (method == HttpMethod.Get || method == HttpMethod.Head);
-        }
-
-        /// <summary>
-        /// Determines whether caching headers have already been applied. We look for "Cache-Control" and "Expires".
-        /// We don't look for just "Pragma" as this is not a reliable header for control caching.
-        /// </summary>
-        /// <param name="response">The <see cref="HttpResponseMessage"/>.</param>
-        /// <returns><c>true</c> if either "Cache-Control" or "Expires" has been set.</returns>
-        internal static bool HasCachingHeaders(HttpResponseMessage response)
-        {
-            IEnumerable<string> expires;
-            return response != null
-                && (response.Headers.CacheControl != null
-                || (response.Content != null && response.Content.Headers.TryGetValues("Expires", out expires)));
+            IMobileAppControllerConfigProvider configurationProvider = controllerDescriptor.Configuration.GetMobileAppControllerConfigProvider();
+            configurationProvider.Configure(controllerSettings, controllerDescriptor);
         }
     }
 }

--- a/src/Microsoft.Azure.Mobile.Server/Config/MobileAppControllerConfigProvider.cs
+++ b/src/Microsoft.Azure.Mobile.Server/Config/MobileAppControllerConfigProvider.cs
@@ -1,0 +1,54 @@
+﻿// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+using System;
+using System.Globalization;
+using System.Net.Http.Formatting;
+using System.Web.Http.Controllers;
+using Microsoft.Azure.Mobile.Server.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Microsoft.Azure.Mobile.Server.Config
+{
+    /// <summary>
+    /// A default implementation of <see cref="IMobileAppControllerConfigProvider" /> that configures the JSON
+    /// serializer settings for use with Mobile App clients.
+    /// </summary>
+    public class MobileAppControllerConfigProvider : IMobileAppControllerConfigProvider
+    {
+        /// <inheritdoc />
+        public virtual void Configure(HttpControllerSettings controllerSettings, HttpControllerDescriptor controllerDescriptor)
+        {
+            if (controllerSettings == null)
+            {
+                throw new ArgumentNullException("controllerSettings");
+            }
+
+            JsonMediaTypeFormatter jsonFormatter = new JsonMediaTypeFormatter();
+            JsonSerializerSettings serializerSettings = jsonFormatter.SerializerSettings;
+
+            // Set up date/time format to be ISO 8601 but with 3 digits and "Z" as UTC time indicator. This format
+            // is the JS-valid format accepted by most JS clients.
+            IsoDateTimeConverter dateTimeConverter = new IsoDateTimeConverter()
+            {
+                Culture = CultureInfo.InvariantCulture,
+                DateTimeFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFZ",
+                DateTimeStyles = DateTimeStyles.AdjustToUniversal
+            };
+
+            // Ignoring default values while serializing was affecting offline scenarios as client sdk looks at first object in a batch for the properties.
+            // If first row in the server response did not include columns with default values, client sdk ignores these columns for the rest of the rows
+            serializerSettings.DefaultValueHandling = DefaultValueHandling.Include;
+            serializerSettings.NullValueHandling = NullValueHandling.Include;
+            serializerSettings.Converters.Add(new StringEnumConverter());
+            serializerSettings.Converters.Add(dateTimeConverter);
+            serializerSettings.MissingMemberHandling = MissingMemberHandling.Error;
+            serializerSettings.CheckAdditionalContent = true;
+            serializerSettings.ContractResolver = new ServiceContractResolver(jsonFormatter);
+            controllerSettings.Formatters.Remove(controllerSettings.Formatters.JsonFormatter);
+            controllerSettings.Formatters.Insert(0, jsonFormatter);
+        }
+    }
+}

--- a/src/Microsoft.Azure.Mobile.Server/Extensions/HttpConfigurationExtensions.cs
+++ b/src/Microsoft.Azure.Mobile.Server/Extensions/HttpConfigurationExtensions.cs
@@ -20,6 +20,7 @@ namespace System.Web.Http
         private const string MobileAppOptionsKey = "MS_MobileAppOptions";
         private const string MobileAppSettingsProviderKey = "MS_MobileAppSettingsProvider";
         private const string CachePolicyProviderKey = "MS_CachePolicyProvider";
+        private const string MobileAppControllerConfigProviderKey = "MS_MobileAppControllerConfigProvider";
 
         /// <summary>
         /// Gets the <see cref="Microsoft.Azure.Mobile.Server.Config.MobileAppConfiguration"/> registered with the current <see cref="System.Web.Http.HttpConfiguration" />.
@@ -123,6 +124,44 @@ namespace System.Web.Http
             }
 
             config.Properties[CachePolicyProviderKey] = provider;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Microsoft.Azure.Mobile.Server.Config.IMobileAppControllerConfigProvider"/> registered with the current <see cref="System.Web.Http.HttpConfiguration" />.
+        /// </summary>
+        /// <param name="config">The current <see cref="System.Web.Http.HttpConfiguration"/>.</param>
+        /// <returns>The registered instance.</returns>
+        public static IMobileAppControllerConfigProvider GetMobileAppControllerConfigProvider(this HttpConfiguration config)
+        {
+            if (config == null)
+            {
+                throw new ArgumentNullException("config");
+            }
+
+            IMobileAppControllerConfigProvider provider = null;
+            if (!config.Properties.TryGetValue(MobileAppControllerConfigProviderKey, out provider))
+            {
+                provider = new MobileAppControllerConfigProvider();
+                config.Properties[MobileAppControllerConfigProviderKey] = provider;
+            }
+
+            return provider;
+        }
+
+        /// <summary>
+        /// Registers an <see cref="Microsoft.Azure.Mobile.Server.Config.IMobileAppControllerConfigProvider"/> with the current <see cref="System.Web.Http.HttpConfiguration" />.
+        /// The registered class provides the base settings for controllers using the <see cref="Microsoft.Azure.Mobile.Server.Config.MobileAppControllerAttribute" />.
+        /// </summary>
+        /// <param name="config">The current <see cref="System.Web.Http.HttpConfiguration"/>.</param>
+        /// <param name="configProvider">The instance to register.</param>
+        public static void SetMobileAppControllerConfigProvider(this HttpConfiguration config, IMobileAppControllerConfigProvider configProvider)
+        {
+            if (config == null)
+            {
+                throw new ArgumentNullException("config");
+            }
+
+            config.Properties[MobileAppControllerConfigProviderKey] = configProvider;
         }
 
         internal static HashSet<string> GetMobileAppControllerNames(this HttpConfiguration config)

--- a/src/Microsoft.Azure.Mobile.Server/Microsoft.Azure.Mobile.Server.csproj
+++ b/src/Microsoft.Azure.Mobile.Server/Microsoft.Azure.Mobile.Server.csproj
@@ -119,9 +119,12 @@
     <Compile Include="Cache\CachePolicyProvider.cs" />
     <Compile Include="Cache\ICachePolicyProvider.cs" />
     <Compile Include="Config\AppConfiguration.cs" />
+    <Compile Include="Config\IMobileAppControllerConfigProvider.cs" />
     <Compile Include="Config\IMobileAppExtensionConfigProvider.cs" />
+    <Compile Include="Config\MobileAppActionFilterAttribute.cs" />
     <Compile Include="Config\MobileAppControllerAttribute.cs" />
     <Compile Include="Config\MobileAppConfiguration.cs" />
+    <Compile Include="Config\MobileAppControllerConfigProvider.cs" />
     <Compile Include="Content\StaticHtmlActionResult.cs" />
     <Compile Include="Config\IAppConfiguration.cs" />
     <Compile Include="LogCategories.cs" />

--- a/test/Common/SerializationAssert.cs
+++ b/test/Common/SerializationAssert.cs
@@ -1,6 +1,6 @@
-﻿// ---------------------------------------------------------------------------- 
+﻿// ----------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// ---------------------------------------------------------------------------- 
+// ----------------------------------------------------------------------------
 
 using System.Collections.Generic;
 using System.Net.Http.Formatting;
@@ -24,7 +24,11 @@ namespace Microsoft.Azure.Mobile
             var config = new HttpConfiguration();
             var controllerSettings = new HttpControllerSettings(config);
             var mobileAppControllerConfig = new MobileAppControllerAttribute();
-            mobileAppControllerConfig.Initialize(controllerSettings, new HttpControllerDescriptor());
+            var controllerDescriptor = new HttpControllerDescriptor()
+            {
+                Configuration = config
+            };
+            mobileAppControllerConfig.Initialize(controllerSettings, controllerDescriptor);
 
             JsonMediaTypeFormatter jsonFormatter = controllerSettings.Formatters.JsonFormatter;
             JsonSerializerSettings settings = jsonFormatter.SerializerSettings;

--- a/test/Microsoft.Azure.Mobile.Server.Authentication.Test/Controllers/SecuredControllerTests.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Authentication.Test/Controllers/SecuredControllerTests.cs
@@ -250,8 +250,6 @@ namespace Microsoft.Azure.Mobile.Server
 
             private AppServiceAuthenticationOptions GetMobileAppAuthOptions(HttpConfiguration config)
             {
-                MobileAppSettingsDictionary settings = config.GetMobileAppSettingsProvider().GetMobileAppSettings();
-
                 return new AppServiceAuthenticationOptions
                 {
                     SigningKey = this.SigningKey,

--- a/test/Microsoft.Azure.Mobile.Server.Authentication.Test/MobileAppAuthenticationHandlerTests.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Authentication.Test/MobileAppAuthenticationHandlerTests.cs
@@ -227,8 +227,6 @@ namespace Microsoft.Azure.Mobile.Server.Security
 
         private static IOwinRequest CreateAuthRequest(Uri webappUri, JwtSecurityToken token = null)
         {
-            string webappBaseUrl = webappUri.GetLeftPart(UriPartial.Authority) + "/";
-
             OwinContext context = new OwinContext();
             IOwinRequest request = context.Request;
             request.Host = HostString.FromUriComponent(webappUri.Host);

--- a/test/Microsoft.Azure.Mobile.Server.Login.Test/AppServiceLoginHandlerTests.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Login.Test/AppServiceLoginHandlerTests.cs
@@ -62,20 +62,15 @@ namespace Microsoft.Azure.Mobile.Server.Login.Test
                 new Claim(JwtRegisteredClaimNames.Sub, UserId)
             };
 
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() =>
+            Assert.Throws<ArgumentNullException>(() =>
                 AppServiceLoginHandler.CreateToken(claims, null, Audience, Issuer, TimeSpan.FromDays(10)));
         }
 
         [Fact]
         public void CreateToken_Throws_IfClaimsNull()
         {
-            Claim[] claims = new Claim[]
-            {
-                new Claim(JwtRegisteredClaimNames.Sub, UserId)
-            };
-
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() =>
-                AppServiceLoginHandler.CreateToken(null, SigningKey, Audience, Issuer, TimeSpan.FromDays(10)));
+            Assert.Throws<ArgumentNullException>(() =>
+                  AppServiceLoginHandler.CreateToken(null, SigningKey, Audience, Issuer, TimeSpan.FromDays(10)));
         }
 
         [Fact]

--- a/test/Microsoft.Azure.Mobile.Server.Quickstart.Test/Config/MobileAppConfigSetupTests.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Quickstart.Test/Config/MobileAppConfigSetupTests.cs
@@ -96,8 +96,10 @@ namespace Microsoft.Azure.Mobile.Server.Config
                 var tableGet = await client.GetAsync("tables/testtable");
                 var tableGetApplication = await client.GetAsync("tables/testtable/someId");
                 var tableGetApiRoute = await client.GetAsync("api/testtable");
-                var apiGetAnonymous = await client.GetAsync("api/secured/anonymous");
-                var apiGetAuthorize = await client.GetAsync("api/secured/authorize");
+                var apiGetAnonymous = await client.GetAsync("auth/anonymous");
+                var apiGetAuthorize = await client.GetAsync("auth/authorize");
+                var apiDirectRoute = await client.GetAsync("api/testapi");
+                var apiGetTableRoute = await client.GetAsync("table/testapi");
 
                 // Assert
                 Assert.Equal(HttpStatusCode.OK, notificationsPut.StatusCode);
@@ -115,17 +117,23 @@ namespace Microsoft.Azure.Mobile.Server.Config
                 ValidateHeaders(tableGetApplication, true);
 
                 // Succeeds: TableControllers will show up in the api route as well.
-                Assert.Equal(HttpStatusCode.OK, tableGetApiRoute.StatusCode);
+                Assert.Equal(HttpStatusCode.NotFound, tableGetApiRoute.StatusCode);
                 ValidateHeaders(tableGetApiRoute, true);
 
                 // Succeeds: Auth is not set up so no ServiceUser is created. But
-                // the AuthorizeAttribute lets these through.
+                // the AllowAnonymousAttribute lets these through.
                 Assert.Equal(HttpStatusCode.OK, apiGetAnonymous.StatusCode);
                 ValidateHeaders(apiGetAnonymous, false);
 
-                // Succeeds: Api action with no AuthorizeLevel attribute
+                Assert.Equal(HttpStatusCode.OK, apiDirectRoute.StatusCode);
+                ValidateHeaders(apiDirectRoute, true);
+
+                Assert.Equal(HttpStatusCode.NotFound, apiGetTableRoute.StatusCode);
+                ValidateHeaders(apiGetTableRoute, true);
+
                 Assert.Equal(isAuthenticated ? HttpStatusCode.OK : HttpStatusCode.Unauthorized, apiGetAuthorize.StatusCode);
                 ValidateHeaders(apiGetAuthorize, false);
+
                 if (isAuthenticated)
                 {
                     string requestAuthToken = apiGetAuthorize.RequestMessage.Headers.Single(h => h.Key == "x-zumo-auth").Value.Single();

--- a/test/Microsoft.Azure.Mobile.Server.Quickstart.Test/Microsoft.Azure.Mobile.Server.Quickstart.Test.csproj
+++ b/test/Microsoft.Azure.Mobile.Server.Quickstart.Test/Microsoft.Azure.Mobile.Server.Quickstart.Test.csproj
@@ -142,6 +142,7 @@
     <Compile Include="Config\MobileAppAppBuilderExtensionTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestControllers\SecuredController.cs" />
+    <Compile Include="TestControllers\TestApiController.cs" />
     <Compile Include="TestControllers\TestTableController.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Microsoft.Azure.Mobile.Server.Quickstart.Test/TestControllers/SecuredController.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Quickstart.Test/TestControllers/SecuredController.cs
@@ -1,10 +1,12 @@
-﻿// ---------------------------------------------------------------------------- 
+﻿// ----------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// ---------------------------------------------------------------------------- 
+// ----------------------------------------------------------------------------
 
 using System.Linq;
+using System.Net.Http;
 using System.Security.Claims;
 using System.Web.Http;
+using Microsoft.Azure.Mobile.Server.Config;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.Mobile.Server.TestControllers
@@ -13,14 +15,16 @@ namespace Microsoft.Azure.Mobile.Server.TestControllers
     public class SecuredController : ApiController
     {
         [AllowAnonymous]
-        [Route("api/secured/anonymous")]
-        public IHttpActionResult GetAnonymous()
+        [Route("auth/anonymous")]
+        [HttpGet]
+        public IHttpActionResult AuthNotRequired()
         {
             return this.GetUserDetails();
         }
 
-        [Route("api/secured/authorize")]
-        public string GetApplication()
+        [Route("auth/authorize")]
+        [HttpGet]
+        public string AuthRequired()
         {
             return this.Request.Headers.GetValues("x-zumo-auth").FirstOrDefault<string>();
         }
@@ -39,7 +43,7 @@ namespace Microsoft.Azure.Mobile.Server.TestControllers
                 }
                 details = new JObject
                 {
-                    { "id", userId }               
+                    { "id", userId }
                 };
             }
 

--- a/test/Microsoft.Azure.Mobile.Server.Quickstart.Test/TestControllers/TestApiController.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Quickstart.Test/TestControllers/TestApiController.cs
@@ -1,0 +1,19 @@
+﻿// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+using System.Web.Http;
+using Microsoft.Azure.Mobile.Server.Config;
+
+namespace Microsoft.Azure.Mobile.Server.Quickstart.Test.TestControllers
+{
+    [MobileAppController]
+    public class TestApiController : ApiController
+    {
+        [HttpGet]
+        public string NoAttribute()
+        {
+            return "Hello";
+        }
+    }
+}

--- a/test/Microsoft.Azure.Mobile.Server.Tables.Test/Extensions/TableHttpConfigurationExtensionTests.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Tables.Test/Extensions/TableHttpConfigurationExtensionTests.cs
@@ -1,0 +1,98 @@
+﻿// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+using System.Web.Http;
+using System.Web.Http.Dispatcher;
+using Microsoft.Azure.Mobile.Server.Config;
+using Microsoft.Azure.Mobile.Server.Tables;
+using Microsoft.Azure.Mobile.Server.TestControllers;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.Mobile.Server.Extensions
+{
+    public class TableHttpConfigurationExtensionTests
+    {
+        [Fact]
+        public void GetTableControllerConfigProvider_ReturnsDefaultInstance()
+        {
+            // Arrange
+            HttpConfiguration config = new HttpConfiguration();
+
+            // Act
+            ITableControllerConfigProvider actual = config.GetTableControllerConfigProvider();
+
+            // Assert
+            Assert.NotNull(actual);
+            Assert.IsType<TableControllerConfigProvider>(actual);
+        }
+
+        [Fact]
+        public void SetMobileAppControllerConfigProvider_Roundtrips()
+        {
+            // Arrange
+            TableControllerConfigProvider provider = new TableControllerConfigProvider();
+            HttpConfiguration config = new HttpConfiguration();
+
+            // Act
+            config.SetTableControllerConfigProvider(provider);
+            ITableControllerConfigProvider actual = config.GetTableControllerConfigProvider();
+
+            // Assert
+            Assert.Same(provider, actual);
+        }
+
+        [Fact]
+        public void SetMobileAppControllerConfigProvider_ReturnsDefault_IfSetToNull()
+        {
+            // Arrange
+            HttpConfiguration config = new HttpConfiguration();
+
+            // Act
+            config.SetMobileAppControllerConfigProvider(null);
+            ITableControllerConfigProvider actual = config.GetTableControllerConfigProvider();
+
+            // Assert
+            Assert.NotNull(actual);
+            Assert.IsType<TableControllerConfigProvider>(actual);
+        }
+
+        [Fact]
+        public void GetTableControllerNames_ReturnsCorrectControllers()
+        {
+            // Arrange
+            var typeList = new[]
+            {
+                typeof(MoviesController),
+                typeof(ZetaController),
+                typeof(TestTableController),
+                typeof(ApiController),
+                typeof(CustomController),
+                typeof(DerivedMoviesController)
+            };
+
+            HttpConfiguration config = new HttpConfiguration();
+            IAssembliesResolver assemblyResolver = config.Services.GetAssembliesResolver();
+            Mock<IHttpControllerTypeResolver> typeResolverMock = new Mock<IHttpControllerTypeResolver>();
+            typeResolverMock.Setup(m => m.GetControllerTypes(assemblyResolver)).Returns(typeList);
+
+            config.Services.Replace(typeof(IHttpControllerTypeResolver), typeResolverMock.Object);
+
+            // Act
+            var names = config.GetTableControllerNames();
+
+            // Assert
+            Assert.Equal(new[] { "Movies", "TestTable", "DerivedMovies" }, names);
+        }
+
+        private class DerivedMoviesController : MoviesController
+        {
+        }
+
+        [MobileAppController]
+        private class CustomController : ApiController
+        {
+        }
+    }
+}

--- a/test/Microsoft.Azure.Mobile.Server.Tables.Test/Microsoft.Azure.Mobile.Server.Tables.Test.csproj
+++ b/test/Microsoft.Azure.Mobile.Server.Tables.Test/Microsoft.Azure.Mobile.Server.Tables.Test.csproj
@@ -188,6 +188,7 @@
     <Compile Include="Controllers\EntityTableControllerQueryTests.cs" />
     <Compile Include="Controllers\MappedEntityTableControllerUpdateTests.cs" />
     <Compile Include="Controllers\VersionTableControllerTests.cs" />
+    <Compile Include="Extensions\TableHttpConfigurationExtensionTests.cs" />
     <Compile Include="Extensions\TableHttpRequestMessageExtensionsTests.cs" />
     <Compile Include="Extensions\TableTypeExtensionsTests.cs" />
     <Compile Include="Headers\LinkHeaderTests.cs" />
@@ -199,6 +200,7 @@
     <Compile Include="Tables\QueryResultTests.cs" />
     <Compile Include="Tables\TableColumnAttributeTests.cs" />
     <Compile Include="Tables\TableControllerConfigAttributeTests.cs" />
+    <Compile Include="Tables\TableControllerConfigProviderTests.cs" />
     <Compile Include="Tables\TableFilterProviderTests.cs" />
     <Compile Include="Tables\TableQueryFilterTests.cs" />
     <Compile Include="Tables\TableUtilsTests.cs" />

--- a/test/Microsoft.Azure.Mobile.Server.Tables.Test/Tables/TableControllerConfigProviderTests.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Tables.Test/Tables/TableControllerConfigProviderTests.cs
@@ -1,0 +1,39 @@
+﻿// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+using System.Linq;
+using System.Web.Http;
+using System.Web.Http.Controllers;
+using Microsoft.Azure.Mobile.Server.Serialization;
+using Microsoft.Azure.Mobile.Server.Tables;
+using Xunit;
+
+namespace Microsoft.Azure.Mobile.Server.Config
+{
+    public class TableControllerConfigProviderTests
+    {
+        [Fact]
+        public void TableConfigProvider_SettingsAreCorrect()
+        {
+            // Arrange
+            var config = new HttpConfiguration();
+            var configProvider = new TableControllerConfigProvider();
+            var settings = new HttpControllerSettings(config);
+            var descriptor = new HttpControllerDescriptor()
+            {
+                Configuration = config
+            };
+
+            // Act
+            configProvider.Configure(settings, descriptor);
+
+            // Assert
+            // Verify SerializerSettings are set up as we expect
+            Assert.Null(settings.Formatters.XmlFormatter);
+            var filterProvider = config.Services.GetFilterProviders().OfType<TableFilterProvider>();
+            Assert.NotNull(filterProvider);
+            Assert.IsType<TableContractResolver>(settings.Formatters.JsonFormatter.SerializerSettings.ContractResolver);
+        }
+    }
+}

--- a/test/Microsoft.Azure.Mobile.Server.Test/Config/MobileAppActionFilterTests.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Test/Config/MobileAppActionFilterTests.cs
@@ -1,0 +1,215 @@
+﻿// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Web.Http;
+using System.Web.Http.Controllers;
+using System.Web.Http.Filters;
+using Microsoft.Azure.Mobile.Server.Cache;
+using Microsoft.Azure.Mobile.Server.Serialization;
+using Moq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using TestUtilities;
+using Xunit;
+
+namespace Microsoft.Azure.Mobile.Server.Config
+{
+    public class MobileAppActionFilterTests
+    {
+        private HttpConfiguration nullConfig = new HttpConfiguration();
+        private HttpConfiguration config;
+        private Mock<ICachePolicyProvider> providerMock;
+        private HttpRequestMessage request;
+        private MobileAppActionFilterAttribute mobileAppActionFilterAttr;
+        private HttpActionExecutedContext actionExecutedContext;
+        private HttpControllerContext controllerContext;
+        private HttpActionContext actionContext;
+
+        public MobileAppActionFilterTests()
+        {
+            this.providerMock = new Mock<ICachePolicyProvider>();
+            this.config = new HttpConfiguration();
+            this.config.SetCachePolicyProvider(this.providerMock.Object);
+
+            this.request = new HttpRequestMessage();
+            this.mobileAppActionFilterAttr = new MobileAppActionFilterAttribute();
+            this.actionExecutedContext = new HttpActionExecutedContext();
+            this.controllerContext = new HttpControllerContext();
+            this.controllerContext.Configuration = this.nullConfig;
+            this.controllerContext.Request = this.request;
+            this.actionContext = new HttpActionContext();
+            this.actionContext.ControllerContext = this.controllerContext;
+            this.actionExecutedContext.ActionContext = this.actionContext;
+        }
+
+        public static TheoryDataCollection<HttpMethod, bool> CacheableHttpMethods
+        {
+            get
+            {
+                return new TheoryDataCollection<HttpMethod, bool>
+                {
+                    { null, false },
+                    { HttpMethod.Get, true },
+                    { HttpMethod.Head, true },
+                    { HttpMethod.Delete, false },
+                    { HttpMethod.Options, false },
+                    { HttpMethod.Post, false },
+                    { HttpMethod.Put, false },
+                    { HttpMethod.Trace, false },
+                    { new HttpMethod("PATCH"), false },
+                    { new HttpMethod("UNKNOWN"), false },
+                };
+            }
+        }
+
+        public static TheoryDataCollection<HttpResponseMessage, bool> CacheResponses
+        {
+            get
+            {
+                HttpResponseMessage rspNone = new HttpResponseMessage();
+                rspNone.Headers.ETag = new EntityTagHeaderValue("\"quotedstring\"");
+
+                HttpResponseMessage rspCacheControl1 = new HttpResponseMessage();
+                rspCacheControl1.Headers.CacheControl = new CacheControlHeaderValue();
+
+                HttpResponseMessage rspCacheControl2 = new HttpResponseMessage();
+                rspCacheControl2.Headers.CacheControl = new CacheControlHeaderValue();
+                rspCacheControl2.Headers.CacheControl.NoCache = true;
+
+                HttpResponseMessage rspExpires1 = new HttpResponseMessage();
+                rspExpires1.Content = new StringContent("Hello");
+                rspExpires1.Content.Headers.Expires = DateTimeOffset.UtcNow;
+
+                HttpResponseMessage rspExpires2 = new HttpResponseMessage();
+                rspExpires2.Content = new StringContent("Hello");
+                rspExpires2.Content.Headers.TryAddWithoutValidation("Expires", "0");
+
+                return new TheoryDataCollection<HttpResponseMessage, bool>
+                {
+                    { null, false },
+                    { rspNone, false },
+                    { new HttpResponseMessage(), false },
+                    { rspCacheControl1, true },
+                    { rspCacheControl2, true },
+                    { rspExpires1, true },
+                    { rspExpires2, true },
+                };
+            }
+        }
+
+        public static TheoryDataCollection<HttpMethod, HttpResponseMessage, bool> CallSetPolicy
+        {
+            get
+            {
+                HttpResponseMessage rspNone = new HttpResponseMessage();
+                rspNone.Headers.ETag = new EntityTagHeaderValue("\"quotedstring\"");
+
+                HttpResponseMessage rspCacheControl1 = new HttpResponseMessage();
+                rspCacheControl1.Headers.CacheControl = new CacheControlHeaderValue();
+
+                HttpResponseMessage rspCacheControl2 = new HttpResponseMessage();
+                rspCacheControl2.Headers.CacheControl = new CacheControlHeaderValue();
+                rspCacheControl2.Headers.CacheControl.NoCache = true;
+
+                HttpResponseMessage rspExpires1 = new HttpResponseMessage();
+                rspExpires1.Content = new StringContent("Hello");
+                rspExpires1.Content.Headers.Expires = DateTimeOffset.UtcNow;
+
+                HttpResponseMessage rspExpires2 = new HttpResponseMessage();
+                rspExpires2.Content = new StringContent("Hello");
+                rspExpires2.Content.Headers.TryAddWithoutValidation("Expires", "0");
+
+                return new TheoryDataCollection<HttpMethod, HttpResponseMessage, bool>
+                {
+                    { HttpMethod.Get, rspNone, true },
+                    { HttpMethod.Get, null, false },
+                    { HttpMethod.Post, rspNone, false },
+                    { HttpMethod.Get, rspCacheControl1, false },
+                    { HttpMethod.Post, rspCacheControl1, false },
+                    { HttpMethod.Get, rspCacheControl2, false },
+                    { HttpMethod.Post, rspCacheControl2, false },
+                    { HttpMethod.Get, rspExpires1, false },
+                    { HttpMethod.Post, rspExpires1, false },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData("CacheResponses")]
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "notUsed", Justification = "Part of test data")]
+        public void SendAsync_PassesResponseThrough_IfNullCachePolicyProvider(HttpResponseMessage response, bool notUsed)
+        {
+            // Arrange
+            this.actionExecutedContext.Response = response;
+
+            // Act
+            this.mobileAppActionFilterAttr.OnActionExecuted(this.actionExecutedContext);
+
+            // Assert
+            // Make sure the response didn't change
+            Assert.Equal(response, this.actionExecutedContext.Response);
+        }
+
+        [Theory]
+        [MemberData("CallSetPolicy")]
+        public void SendAsync_CallsSetPolicy_IfCacheableMethodAndNoCacheHeadersPresent(HttpMethod method, HttpResponseMessage response, bool shouldCall)
+        {
+            // Arrange
+            this.controllerContext.Request = new HttpRequestMessage(method, "http://localhost");
+            this.controllerContext.Configuration = this.config;
+            this.actionExecutedContext.Response = response;
+
+            // Act
+            this.mobileAppActionFilterAttr.OnActionExecuted(this.actionExecutedContext);
+
+            // Assert
+            this.providerMock.Verify(p => p.SetCachePolicy(response), shouldCall ? Times.Once() : Times.Never());
+        }
+
+        [Theory]
+        [MemberData("CacheableHttpMethods")]
+        public void IsCacheableMethod_ReturnsTrueForCacheableMethods(HttpMethod method, bool expected)
+        {
+            // Act
+            bool actual = MobileAppActionFilterAttribute.IsCacheableMethod(method);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [MemberData("CacheResponses")]
+        public void HasCachingHeaders_ReturnsTrueWhenCacheControlOrExpiresIsPresent(HttpResponseMessage response, bool expected)
+        {
+            // Act
+            bool actual = MobileAppActionFilterAttribute.HasCachingHeaders(response);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void SetVersionHeader_SetsVersionHeader()
+        {
+            // Arrange
+            HttpResponseMessage response = new HttpResponseMessage();
+            Assembly asm = typeof(MobileAppActionFilterAttribute).Assembly;
+            string expected = "net-" + AssemblyUtils.GetExecutingAssemblyFileVersionOrDefault(asm);
+
+            // Act
+            MobileAppActionFilterAttribute.SetVersionHeader(response);
+            string actual = response.Headers.GetValues("x-zumo-server-version").Single();
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/test/Microsoft.Azure.Mobile.Server.Test/Config/MobileAppConfigurationTests.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Test/Config/MobileAppConfigurationTests.cs
@@ -1,0 +1,84 @@
+﻿// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+using System.Web.Http;
+using System.Web.Http.Controllers;
+using Xunit;
+
+namespace Microsoft.Azure.Mobile.Server.Config
+{
+    public class MobileAppConfigurationTests
+    {
+        [Fact]
+        public void WithMobileAppControllerConfigProvider_Default_IsCorrect()
+        {
+            var config = new HttpConfiguration();
+            new MobileAppConfiguration()
+                .ApplyTo(config);
+
+            var provider = config.GetMobileAppControllerConfigProvider();
+            Assert.NotNull(provider);
+            Assert.IsType<MobileAppControllerConfigProvider>(provider);
+        }
+
+        [Fact]
+        public void WithMobileAppControllerConfigProvider_CanBeOverridden()
+        {
+            var config = new HttpConfiguration();
+            var myProvider = new MyProvider();
+            new MobileAppConfiguration()
+                .WithMobileAppControllerConfigProvider(myProvider)
+                .ApplyTo(config);
+
+            var provider = config.GetMobileAppControllerConfigProvider();
+            Assert.NotNull(provider);
+            Assert.Same(myProvider, provider);
+            Assert.IsType<MyProvider>(provider);
+        }
+
+        [Fact]
+        public void MapApiControllers_IsFalse_ByDefault()
+        {
+            // Arrange
+            var config = new HttpConfiguration();
+
+            // Act
+            new MobileAppConfiguration()
+                .ApplyTo(config);
+
+            // Assert
+            Assert.Empty(config.Routes);
+        }
+
+        [Fact]
+        public void MapApiControllers_AddsApiRoute_WithConstraint()
+        {
+            // Arrange
+            var config = new HttpConfiguration();
+
+            // Act
+            new MobileAppConfiguration()
+                .MapApiControllers()
+                .ApplyTo(config);
+
+            // Assert
+            Assert.Equal(1, config.Routes.Count);
+
+            var route = config.Routes[0];
+            Assert.Equal("api/{controller}/{id}", route.RouteTemplate);
+            Assert.Equal(1, route.Constraints.Count);
+            var constraint = route.Constraints["controller"] as SetRouteConstraint<string>;
+            Assert.NotNull(constraint);
+            Assert.Equal(false, constraint.Excluded);
+            Assert.Equal(config.GetMobileAppControllerNames(), constraint.Set);
+        }
+
+        private class MyProvider : IMobileAppControllerConfigProvider
+        {
+            public void Configure(HttpControllerSettings controllerSettings, HttpControllerDescriptor controllerDescriptor)
+            {
+            }
+        }
+    }
+}

--- a/test/Microsoft.Azure.Mobile.Server.Test/Config/MobileAppControllerAttributeTests.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Test/Config/MobileAppControllerAttributeTests.cs
@@ -24,222 +24,25 @@ namespace Microsoft.Azure.Mobile.Server.Config
 {
     public class MobileAppControllerAttributeTests
     {
-        private HttpConfiguration nullConfig = new HttpConfiguration();
-        private HttpConfiguration config;
-        private Mock<ICachePolicyProvider> providerMock;
-        private HttpRequestMessage request;
-        private MobileAppControllerAttribute mobileAppControllerAttr;
-        private HttpActionExecutedContext actionExecutedContext;
-        private HttpControllerContext controllerContext;
-        private HttpActionContext actionContext;
-
-        public MobileAppControllerAttributeTests()
-        {
-            this.providerMock = new Mock<ICachePolicyProvider>();
-            this.config = new HttpConfiguration();
-            this.config.SetCachePolicyProvider(this.providerMock.Object);
-
-            this.request = new HttpRequestMessage();
-            this.mobileAppControllerAttr = new MobileAppControllerAttribute();
-            this.actionExecutedContext = new HttpActionExecutedContext();
-            this.controllerContext = new HttpControllerContext();
-            this.controllerContext.Configuration = this.nullConfig;
-            this.controllerContext.Request = this.request;
-            this.actionContext = new HttpActionContext();
-            this.actionContext.ControllerContext = this.controllerContext;
-            this.actionExecutedContext.ActionContext = this.actionContext;
-        }
-
-        public static TheoryDataCollection<HttpMethod, bool> CacheableHttpMethods
-        {
-            get
-            {
-                return new TheoryDataCollection<HttpMethod, bool>
-                {
-                    { null, false },
-                    { HttpMethod.Get, true },
-                    { HttpMethod.Head, true },
-                    { HttpMethod.Delete, false },
-                    { HttpMethod.Options, false },
-                    { HttpMethod.Post, false },
-                    { HttpMethod.Put, false },
-                    { HttpMethod.Trace, false },
-                    { new HttpMethod("PATCH"), false },
-                    { new HttpMethod("UNKNOWN"), false },
-                };
-            }
-        }
-
-        public static TheoryDataCollection<HttpResponseMessage, bool> CacheResponses
-        {
-            get
-            {
-                HttpResponseMessage rspNone = new HttpResponseMessage();
-                rspNone.Headers.ETag = new EntityTagHeaderValue("\"quotedstring\"");
-
-                HttpResponseMessage rspCacheControl1 = new HttpResponseMessage();
-                rspCacheControl1.Headers.CacheControl = new CacheControlHeaderValue();
-
-                HttpResponseMessage rspCacheControl2 = new HttpResponseMessage();
-                rspCacheControl2.Headers.CacheControl = new CacheControlHeaderValue();
-                rspCacheControl2.Headers.CacheControl.NoCache = true;
-
-                HttpResponseMessage rspExpires1 = new HttpResponseMessage();
-                rspExpires1.Content = new StringContent("Hello");
-                rspExpires1.Content.Headers.Expires = DateTimeOffset.UtcNow;
-
-                HttpResponseMessage rspExpires2 = new HttpResponseMessage();
-                rspExpires2.Content = new StringContent("Hello");
-                rspExpires2.Content.Headers.TryAddWithoutValidation("Expires", "0");
-
-                return new TheoryDataCollection<HttpResponseMessage, bool>
-                {
-                    { null, false },
-                    { rspNone, false },
-                    { new HttpResponseMessage(), false },
-                    { rspCacheControl1, true },
-                    { rspCacheControl2, true },
-                    { rspExpires1, true },
-                    { rspExpires2, true },
-                };
-            }
-        }
-
-        public static TheoryDataCollection<HttpMethod, HttpResponseMessage, bool> CallSetPolicy
-        {
-            get
-            {
-                HttpResponseMessage rspNone = new HttpResponseMessage();
-                rspNone.Headers.ETag = new EntityTagHeaderValue("\"quotedstring\"");
-
-                HttpResponseMessage rspCacheControl1 = new HttpResponseMessage();
-                rspCacheControl1.Headers.CacheControl = new CacheControlHeaderValue();
-
-                HttpResponseMessage rspCacheControl2 = new HttpResponseMessage();
-                rspCacheControl2.Headers.CacheControl = new CacheControlHeaderValue();
-                rspCacheControl2.Headers.CacheControl.NoCache = true;
-
-                HttpResponseMessage rspExpires1 = new HttpResponseMessage();
-                rspExpires1.Content = new StringContent("Hello");
-                rspExpires1.Content.Headers.Expires = DateTimeOffset.UtcNow;
-
-                HttpResponseMessage rspExpires2 = new HttpResponseMessage();
-                rspExpires2.Content = new StringContent("Hello");
-                rspExpires2.Content.Headers.TryAddWithoutValidation("Expires", "0");
-
-                return new TheoryDataCollection<HttpMethod, HttpResponseMessage, bool>
-                {
-                    { HttpMethod.Get, rspNone, true },
-                    { HttpMethod.Get, null, false },
-                    { HttpMethod.Post, rspNone, false },
-                    { HttpMethod.Get, rspCacheControl1, false },
-                    { HttpMethod.Post, rspCacheControl1, false },
-                    { HttpMethod.Get, rspCacheControl2, false },
-                    { HttpMethod.Post, rspCacheControl2, false },
-                    { HttpMethod.Get, rspExpires1, false },
-                    { HttpMethod.Post, rspExpires1, false },
-                };
-            }
-        }
-
         [Fact]
-        public void Initialize_Initializes_SerializerSettings()
+        public void Initialize_CallsRegisteredConfigProvider()
         {
             // Arrange
+            var config = new HttpConfiguration();
+            var mockConfigProvider = new Mock<IMobileAppControllerConfigProvider>();
+            config.SetMobileAppControllerConfigProvider(mockConfigProvider.Object);
             var attr = new MobileAppControllerAttribute();
-            var settings = new HttpControllerSettings(this.nullConfig);
+            var settings = new HttpControllerSettings(config);
+            var descriptor = new HttpControllerDescriptor()
+            {
+                Configuration = config
+            };
 
             // Act
-            attr.Initialize(settings, null);
+            attr.Initialize(settings, descriptor);
 
             // Assert
-            // Verify SerializerSettings are set up as we expect
-            var serializerSettings = settings.Formatters.JsonFormatter.SerializerSettings;
-            Assert.Equal(typeof(ServiceContractResolver), serializerSettings.ContractResolver.GetType());
-            Assert.Equal(DefaultValueHandling.Include, serializerSettings.DefaultValueHandling);
-            Assert.Equal(NullValueHandling.Include, serializerSettings.NullValueHandling);
-
-            // Verify Converters
-            var stringEnumConverter = serializerSettings.Converters.Single(c => c.GetType() == typeof(StringEnumConverter)) as StringEnumConverter;
-            Assert.False(stringEnumConverter.CamelCaseText);
-
-            var isoDateTimeConverter = serializerSettings.Converters.Single(c => c.GetType() == typeof(IsoDateTimeConverter)) as IsoDateTimeConverter;
-            Assert.Equal(DateTimeStyles.AdjustToUniversal, isoDateTimeConverter.DateTimeStyles);
-            Assert.Equal("yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFZ", isoDateTimeConverter.DateTimeFormat);
-            Assert.Equal(CultureInfo.InvariantCulture, isoDateTimeConverter.Culture);
-
-            Assert.NotSame(this.nullConfig.Formatters.JsonFormatter.SerializerSettings.ContractResolver, settings.Formatters.JsonFormatter.SerializerSettings.ContractResolver);
-            Assert.Same(settings.Formatters.JsonFormatter, settings.Formatters[0]);
-        }
-
-        [Theory]
-        [MemberData("CacheResponses")]
-        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "notUsed", Justification = "Part of test data")]
-        public void SendAsync_PassesResponseThrough_IfNullCachePolicyProvider(HttpResponseMessage response, bool notUsed)
-        {
-            // Arrange
-            this.actionExecutedContext.Response = response;
-
-            // Act
-            this.mobileAppControllerAttr.OnActionExecuted(this.actionExecutedContext);
-
-            // Assert
-            // Make sure the response didn't change
-            Assert.Equal(response, this.actionExecutedContext.Response);
-        }
-
-        [Theory]
-        [MemberData("CallSetPolicy")]
-        public void SendAsync_CallsSetPolicy_IfCacheableMethodAndNoCacheHeadersPresent(HttpMethod method, HttpResponseMessage response, bool shouldCall)
-        {
-            // Arrange
-            this.controllerContext.Request = new HttpRequestMessage(method, "http://localhost");
-            this.controllerContext.Configuration = this.config;
-            this.actionExecutedContext.Response = response;
-
-            // Act
-            this.mobileAppControllerAttr.OnActionExecuted(this.actionExecutedContext);
-
-            // Assert
-            this.providerMock.Verify(p => p.SetCachePolicy(response), shouldCall ? Times.Once() : Times.Never());
-        }
-
-        [Theory]
-        [MemberData("CacheableHttpMethods")]
-        public void IsCacheableMethod_ReturnsTrueForCacheableMethods(HttpMethod method, bool expected)
-        {
-            // Act
-            bool actual = MobileAppControllerAttribute.IsCacheableMethod(method);
-
-            // Assert
-            Assert.Equal(expected, actual);
-        }
-
-        [Theory]
-        [MemberData("CacheResponses")]
-        public void HasCachingHeaders_ReturnsTrueWhenCacheControlOrExpiresIsPresent(HttpResponseMessage response, bool expected)
-        {
-            // Act
-            bool actual = MobileAppControllerAttribute.HasCachingHeaders(response);
-
-            // Assert
-            Assert.Equal(expected, actual);
-        }
-
-        [Fact]
-        public void SetVersionHeader_SetsVersionHeader()
-        {
-            // Arrange
-            HttpResponseMessage response = new HttpResponseMessage();
-            Assembly asm = typeof(MobileAppControllerAttribute).Assembly;
-            string expected = "net-" + AssemblyUtils.GetExecutingAssemblyFileVersionOrDefault(asm);
-
-            // Act
-            MobileAppControllerAttribute.SetVersionHeader(response);
-            string actual = response.Headers.GetValues("x-zumo-server-version").Single();
-
-            // Assert
-            Assert.Equal(expected, actual);
+            mockConfigProvider.Verify(m => m.Configure(settings, descriptor), Times.Once);
         }
     }
 }

--- a/test/Microsoft.Azure.Mobile.Server.Test/Config/MobileAppControllerConfigProviderTests.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Test/Config/MobileAppControllerConfigProviderTests.cs
@@ -1,0 +1,55 @@
+﻿// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+using System.Globalization;
+using System.Linq;
+using System.Web.Http;
+using System.Web.Http.Controllers;
+using Microsoft.Azure.Mobile.Server.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Xunit;
+
+namespace Microsoft.Azure.Mobile.Server.Config
+{
+    public class MobileAppControllerConfigProviderTests
+    {
+        [Fact]
+        public void ConfigProvider_SettingsAreCorrect()
+        {
+            // Arrange
+            var config = new HttpConfiguration();
+            var configProvider = new MobileAppControllerConfigProvider();
+            var settings = new HttpControllerSettings(config);
+            var descriptor = new HttpControllerDescriptor()
+            {
+                Configuration = config
+            };
+
+            // Act
+            configProvider.Configure(settings, descriptor);
+
+            // Assert
+            // Verify SerializerSettings are set up as we expect
+            var serializerSettings = settings.Formatters.JsonFormatter.SerializerSettings;
+            Assert.Equal(typeof(ServiceContractResolver), serializerSettings.ContractResolver.GetType());
+            Assert.Equal(DefaultValueHandling.Include, serializerSettings.DefaultValueHandling);
+            Assert.Equal(NullValueHandling.Include, serializerSettings.NullValueHandling);
+            Assert.Equal(MissingMemberHandling.Error, serializerSettings.MissingMemberHandling);
+            Assert.True(serializerSettings.CheckAdditionalContent);
+
+            // Verify Converters
+            var stringEnumConverter = serializerSettings.Converters.Single(c => c.GetType() == typeof(StringEnumConverter)) as StringEnumConverter;
+            Assert.False(stringEnumConverter.CamelCaseText);
+
+            var isoDateTimeConverter = serializerSettings.Converters.Single(c => c.GetType() == typeof(IsoDateTimeConverter)) as IsoDateTimeConverter;
+            Assert.Equal(DateTimeStyles.AdjustToUniversal, isoDateTimeConverter.DateTimeStyles);
+            Assert.Equal("yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFZ", isoDateTimeConverter.DateTimeFormat);
+            Assert.Equal(CultureInfo.InvariantCulture, isoDateTimeConverter.Culture);
+
+            Assert.NotSame(config.Formatters.JsonFormatter.SerializerSettings.ContractResolver, settings.Formatters.JsonFormatter.SerializerSettings.ContractResolver);
+            Assert.Same(settings.Formatters.JsonFormatter, settings.Formatters[0]);
+        }
+    }
+}

--- a/test/Microsoft.Azure.Mobile.Server.Test/Extensions/HttpConfigurationExtensionsTests.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Test/Extensions/HttpConfigurationExtensionsTests.cs
@@ -2,8 +2,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // ----------------------------------------------------------------------------
 
+using System.Web.Http.Dispatcher;
 using Microsoft.Azure.Mobile.Server.Cache;
 using Microsoft.Azure.Mobile.Server.Config;
+using Microsoft.Azure.Mobile.Server.TestControllers;
+using Moq;
 using Xunit;
 
 namespace System.Web.Http
@@ -138,6 +141,102 @@ namespace System.Web.Http
             // Assert
             Assert.NotNull(actual);
             Assert.IsType<CachePolicyProvider>(actual);
+        }
+
+        [Fact]
+        public void GetMobileAppControllerConfigProvider_ReturnsDefaultInstance()
+        {
+            // Arrange
+            HttpConfiguration config = new HttpConfiguration();
+
+            // Act
+            IMobileAppControllerConfigProvider actual = config.GetMobileAppControllerConfigProvider();
+
+            // Assert
+            Assert.NotNull(actual);
+            Assert.IsType<MobileAppControllerConfigProvider>(actual);
+        }
+
+        [Fact]
+        public void SetMobileAppControllerConfigProvider_Roundtrips()
+        {
+            // Arrange
+            MobileAppControllerConfigProvider provider = new MobileAppControllerConfigProvider();
+            HttpConfiguration config = new HttpConfiguration();
+
+            // Act
+            config.SetMobileAppControllerConfigProvider(provider);
+            IMobileAppControllerConfigProvider actual = config.GetMobileAppControllerConfigProvider();
+
+            // Assert
+            Assert.Same(provider, actual);
+        }
+
+        [Fact]
+        public void SetMobileAppControllerConfigProvider_ReturnsDefault_IfSetToNull()
+        {
+            // Arrange
+            HttpConfiguration config = new HttpConfiguration();
+
+            // Act
+            config.SetMobileAppControllerConfigProvider(null);
+            IMobileAppControllerConfigProvider actual = config.GetMobileAppControllerConfigProvider();
+
+            // Assert
+            Assert.NotNull(actual);
+            Assert.IsType<MobileAppControllerConfigProvider>(actual);
+        }
+
+        [Fact]
+        public void GetMobileAppControllerNames_ReturnsCorrectControllers()
+        {
+            // Arrange
+            var typeList = new[]
+            {
+                typeof(CorsController),
+                typeof(TestApiController),
+                typeof(MobileAppActionFilterController),
+                typeof(ApiController),
+                typeof(DerivedMobileAppControllerController),
+                typeof(MockTableController)
+            };
+
+            HttpConfiguration config = new HttpConfiguration();
+            IAssembliesResolver assemblyResolver = config.Services.GetAssembliesResolver();
+            Mock<IHttpControllerTypeResolver> typeResolverMock = new Mock<IHttpControllerTypeResolver>();
+            typeResolverMock.Setup(m => m.GetControllerTypes(assemblyResolver)).Returns(typeList);
+
+            config.Services.Replace(typeof(IHttpControllerTypeResolver), typeResolverMock.Object);
+
+            // Act
+            var names = config.GetMobileAppControllerNames();
+
+            // Assert
+            Assert.Equal(new[] { "Cors", "TestApi", "DerivedMobileAppController" }, names);
+        }
+
+        [MobileAppActionFilter]
+        private class MobileAppActionFilterController : ApiController
+        {
+        }
+
+        private class DerivedMobileAppControllerAttribute : MobileAppControllerAttribute
+        {
+        }
+
+        [DerivedMobileAppController]
+        private class DerivedMobileAppControllerController : ApiController
+        {
+        }
+
+        private class MockTableAppControllerAttribute : MobileAppActionFilterAttribute
+        {
+        }
+
+        // This is similar to how TableController works; make sure it doesn't show up.
+        [MockTableAppController]
+        private class MockTableController : ApiController
+        {
         }
     }
 }

--- a/test/Microsoft.Azure.Mobile.Server.Test/Microsoft.Azure.Mobile.Server.Test.csproj
+++ b/test/Microsoft.Azure.Mobile.Server.Test/Microsoft.Azure.Mobile.Server.Test.csproj
@@ -207,7 +207,10 @@
     <Compile Include="Cache\CachePolicyProviderTests.cs" />
     <Compile Include="Cache\CachePolicyTests.cs" />
     <Compile Include="Config\AppConfigurationTests.cs" />
+    <Compile Include="Config\MobileAppActionFilterTests.cs" />
+    <Compile Include="Config\MobileAppConfigurationTests.cs" />
     <Compile Include="Config\MobileAppControllerAttributeTests.cs" />
+    <Compile Include="Config\MobileAppControllerConfigProviderTests.cs" />
     <Compile Include="Content\StaticHtmlActionResultTests.cs" />
     <Compile Include="Controllers\MobileAppControllerCacheTests.cs" />
     <Compile Include="Controllers\CorsControllerTest.cs" />


### PR DESCRIPTION
Addresses two issues: 

* #48: Introduce new IMobileAppControllerConfigProvider, which works like the already-existing ITableControllerConfigProvider. You can plug one in to modify the default settings for all MobileApp (including Table) controllers.
* #40: Separates all of the ActionFilter logic (CachePolicy and ZUMO-API-VERSION header logic) into a MobileAppActionFilterAttribute. MobileAppController and TableControllerConfigAttribute derive from this now. This lets us map /api routes against MobileAppController directly so tables don't show up in both routes anymore.
* Also adds a bunch more tests, cleans up some CodeAnalysis warnings, and adds a bit more XML docs.