### PR TITLE
improving configurability with IMobileAppControllerConfigProvider

### DIFF
--- a/e2etest/DataObjects/ParamsTestTableEntity.cs
+++ b/e2etest/DataObjects/ParamsTestTableEntity.cs
@@ -2,12 +2,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // ----------------------------------------------------------------------------
 
-using Microsoft.Azure.Mobile.Server.Tables;
 using System;
+using Microsoft.Azure.Mobile.Server.Tables;
 
 namespace ZumoE2EServerApp.DataObjects
 {
-    public class ParamsTestTableEntity : ITableData
+    public sealed class ParamsTestTableEntity : ITableData
     {
         public int Id { get; set; }
         public string Parameters { get; set; }

--- a/samples/SampleApp/SampleApp.csproj
+++ b/samples/SampleApp/SampleApp.csproj
@@ -35,7 +35,7 @@
     <DocumentationFile>bin\Local.XML</DocumentationFile>
     <NoWarn>1591,0618</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <CodeAnalysisRuleSet>..\..\src\Src.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/Microsoft.Azure.Mobile.Server.CrossDomain/Config/CrossDomainExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.Mobile.Server.CrossDomain/Config/CrossDomainExtensionConfigProvider.cs
@@ -1,6 +1,6 @@
-﻿// ---------------------------------------------------------------------------- 
+﻿// ----------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// ---------------------------------------------------------------------------- 
+// ----------------------------------------------------------------------------
 
 using System;
 using System.Collections.Generic;
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Mobile.Server.CrossDomain.Config
     public class CrossDomainExtensionConfigProvider : IMobileAppExtensionConfigProvider
     {
         private IEnumerable<string> domains;
+        private const string CrossDomainControllerName = "crossdomain";
 
         public const string CrossDomainBridgeRouteName = "CrossDomain";
         public const string CrossDomainLoginReceiverRouteName = "CrossDomainLoginReceiver";
@@ -37,17 +38,21 @@ namespace Microsoft.Azure.Mobile.Server.CrossDomain.Config
                 config.SetCrossDomainOrigins(this.domains);
             }
 
+            // register the controller as an exclusion so it does not map to /api
+            MobileAppConfiguration mobileAppConfig = config.GetMobileAppConfiguration();
+            mobileAppConfig.AddBaseRouteExclusion(CrossDomainControllerName);
+
             HttpRouteCollectionExtensions.MapHttpRoute(
                 config.Routes,
                 name: CrossDomainBridgeRouteName,
                 routeTemplate: "crossdomain/bridge",
-                defaults: new { controller = "crossdomain" });
+                defaults: new { controller = CrossDomainControllerName });
 
             HttpRouteCollectionExtensions.MapHttpRoute(
                 config.Routes,
                 name: CrossDomainLoginReceiverRouteName,
                 routeTemplate: "crossdomain/loginreceiver",
-                defaults: new { controller = "crossdomain" });
+                defaults: new { controller = CrossDomainControllerName });
         }
     }
 }

--- a/src/Microsoft.Azure.Mobile.Server.Notifications/Config/NotificationsExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.Mobile.Server.Notifications/Config/NotificationsExtensionConfigProvider.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Mobile.Server.Notifications.Config
     {
         private const string PushRoutePrefix = "push/installations/";
         private const string NotificationInstallationsRouteName = "NotificationInstallations";
+        private const string PushControllerName = "notificationinstallations";
 
         public void Initialize(HttpConfiguration config)
         {
@@ -20,11 +21,15 @@ namespace Microsoft.Azure.Mobile.Server.Notifications.Config
                 throw new ArgumentNullException("config");
             }
 
+            // register the controller as an exclusion so it does not map to /api
+            MobileAppConfiguration mobileAppConfig = config.GetMobileAppConfiguration();
+            mobileAppConfig.AddBaseRouteExclusion(PushControllerName);
+
             HttpRouteCollectionExtensions.MapHttpRoute(
                 config.Routes,
                 name: NotificationInstallationsRouteName,
                 routeTemplate: PushRoutePrefix + "{installationId}",
-                defaults: new { controller = "notificationinstallations" });
+                defaults: new { controller = PushControllerName });
         }
     }
 }

--- a/src/Microsoft.Azure.Mobile.Server.Tables/Config/MapTableControllersExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.Mobile.Server.Tables/Config/MapTableControllersExtensionConfigProvider.cs
@@ -22,6 +22,13 @@ namespace Microsoft.Azure.Mobile.Server.Tables.Config
             HashSet<string> tableControllerNames = config.GetTableControllerNames();
             SetRouteConstraint<string> tableControllerConstraint = new SetRouteConstraint<string>(tableControllerNames, matchOnExcluded: false);
 
+            // register all TableControllers as exclusions so they do not map to /api
+            MobileAppConfiguration mobileAppConfig = config.GetMobileAppConfiguration();
+            foreach (string controllerName in tableControllerNames)
+            {
+                mobileAppConfig.AddBaseRouteExclusion(controllerName);
+            }
+
             HttpRouteCollectionExtensions.MapHttpRoute(
                 config.Routes,
                 name: TablesRouteName,

--- a/src/Microsoft.Azure.Mobile.Server.Tables/Config/MobileAppTableConfiguration.cs
+++ b/src/Microsoft.Azure.Mobile.Server.Tables/Config/MobileAppTableConfiguration.cs
@@ -7,12 +7,15 @@ using Microsoft.Azure.Mobile.Server.Config;
 namespace Microsoft.Azure.Mobile.Server.Tables.Config
 {
     /// <summary>
+    /// Provides configuration methods for Mobile App controllers that derive from <see cref="TableController"/>.
     /// </summary>
     public class MobileAppTableConfiguration : AppConfiguration
     {
         /// <summary>
+        /// Maps all controllers that derive from <see cref="TableController" /> to the
+        /// route template "tables/{controller}/{id}".
         /// </summary>
-        /// <returns></returns>
+        /// <returns>The current <see cref="MobileAppTableConfiguration"/>.</returns>
         public MobileAppTableConfiguration MapTableControllers()
         {
             this.RegisterConfigProvider(new MapTableControllersExtensionConfigProvider());

--- a/src/Microsoft.Azure.Mobile.Server.Tables/Extensions/TableMobileAppOptionsExtensions.cs
+++ b/src/Microsoft.Azure.Mobile.Server.Tables/Extensions/TableMobileAppOptionsExtensions.cs
@@ -3,6 +3,7 @@
 // ----------------------------------------------------------------------------
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Azure.Mobile.Server.Tables;
 using Microsoft.Azure.Mobile.Server.Tables.Config;
@@ -10,14 +11,18 @@ using Microsoft.Azure.Mobile.Server.Tables.Config;
 namespace Microsoft.Azure.Mobile.Server.Config
 {
     /// <summary>
+    /// Extension methods for <see cref="MobileAppConfiguration"/>.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static class TableMobileAppOptionsExtensions
     {
         /// <summary>
+        /// Registers the specified <see cref="ITableControllerConfigProvider" /> with the <see cref="System.Web.Http.HttpConfiguration"/>.
+        /// Use this to override the default <see cref="TableController"/> configuration.
         /// </summary>
-        /// <param name="options"></param>
-        /// <param name="tableConfigProvider"></param>
-        /// <returns></returns>
+        /// <param name="options">The configuration object.</param>
+        /// <param name="tableConfigProvider">The provider to register.</param>
+        /// <returns>The current <see cref="Microsoft.Azure.Mobile.Server.Config.MobileAppConfiguration"/>.</returns>
         [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters", Justification = "We only want this extension to apply to MobileAppConfiguration, not just any AppConfiguration")]
         public static MobileAppConfiguration WithTableControllerConfigProvider(this MobileAppConfiguration options, ITableControllerConfigProvider tableConfigProvider)
         {
@@ -36,9 +41,10 @@ namespace Microsoft.Azure.Mobile.Server.Config
         }
 
         /// <summary>
+        /// Registers a new <see cref="MobileAppTableConfiguration" /> that maps a route for all controllers that derive from <see cref="TableController"/>.
         /// </summary>
-        /// <param name="config"></param>
-        /// <returns></returns>
+        /// <param name="config">The configuration object.</param>
+        /// <returns>The current <see cref="Microsoft.Azure.Mobile.Server.Config.MobileAppConfiguration"/>.</returns>
         public static MobileAppConfiguration AddTables(this MobileAppConfiguration config)
         {
             MobileAppTableConfiguration tableConfig = new MobileAppTableConfiguration().MapTableControllers();
@@ -47,10 +53,11 @@ namespace Microsoft.Azure.Mobile.Server.Config
         }
 
         /// <summary>
+        /// Registers the specified <see cref="MobileAppTableConfiguration"/>.
         /// </summary>
-        /// <param name="config"></param>
+        /// <param name="config">The configuration object.</param>
         /// <param name="tableConfig"></param>
-        /// <returns></returns>
+        /// <returns>The current <see cref="Microsoft.Azure.Mobile.Server.Config.MobileAppConfiguration"/>.</returns>
         [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters", Justification = "We only want this extension to apply to MobileAppConfiguration, not just any AppConfiguration")]
         public static MobileAppConfiguration AddTables(this MobileAppConfiguration config, MobileAppTableConfiguration tableConfig)
         {

--- a/src/Microsoft.Azure.Mobile.Server.Tables/Tables/TableControllerConfigAttribute.cs
+++ b/src/Microsoft.Azure.Mobile.Server.Tables/Tables/TableControllerConfigAttribute.cs
@@ -25,13 +25,8 @@ namespace Microsoft.Azure.Mobile.Server.Tables
 
             base.Initialize(controllerSettings, controllerDescriptor);
 
-            ITableControllerConfigProvider configurationProvider = controllerDescriptor.Configuration.GetTableControllerConfigProvider();
-            if (configurationProvider == null)
-            {
-                configurationProvider = new TableControllerConfigProvider();
-            }
-
-            configurationProvider.Configure(controllerSettings, controllerDescriptor);
+            ITableControllerConfigProvider tableConfigurationProvider = controllerDescriptor.Configuration.GetTableControllerConfigProvider();
+            tableConfigurationProvider.Configure(controllerSettings, controllerDescriptor);
         }
     }
 }

--- a/src/Microsoft.Azure.Mobile.Server.Tables/Tables/TableControllerConfigProvider.cs
+++ b/src/Microsoft.Azure.Mobile.Server.Tables/Tables/TableControllerConfigProvider.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Mobile.Server.Tables
     public class TableControllerConfigProvider : ITableControllerConfigProvider
     {
         /// <inheritdoc />
-        public void Configure(HttpControllerSettings controllerSettings, HttpControllerDescriptor controllerDescriptor)
+        public virtual void Configure(HttpControllerSettings controllerSettings, HttpControllerDescriptor controllerDescriptor)
         {
             if (controllerSettings == null)
             {

--- a/src/Microsoft.Azure.Mobile.Server/Config/IMobileAppControllerConfigProvider.cs
+++ b/src/Microsoft.Azure.Mobile.Server/Config/IMobileAppControllerConfigProvider.cs
@@ -4,16 +4,16 @@
 
 using System.Web.Http.Controllers;
 
-namespace Microsoft.Azure.Mobile.Server.Tables
+namespace Microsoft.Azure.Mobile.Server.Config
 {
     /// <summary>
-    /// Provides an abstraction for performing configuration customizations for <see cref="TableController{TData}"/> derived
-    /// controllers. An implementation can be registered via the <see cref="System.Web.Http.HttpConfiguration"/>.
+    /// Provides an abstraction for performing configuration customizations for controllers with the <see cref="MobileAppControllerAttribute"/>.
+    /// An implementation can be registered via the <see cref="System.Web.Http.HttpConfiguration"/>.
     /// </summary>
-    public interface ITableControllerConfigProvider
+    public interface IMobileAppControllerConfigProvider
     {
         /// <summary>
-        /// Configures the settings specific for controllers of type <see cref="TableController{TData}"/>.
+        /// Configures the settings specific for controllers using <see cref="MobileAppControllerAttribute"/>.
         /// </summary>
         /// <param name="controllerSettings">The <see cref="HttpControllerSettings"/> for this controller type.</param>
         /// <param name="controllerDescriptor">The <see cref="HttpControllerDescriptor"/> for this controller type.</param>

--- a/src/Microsoft.Azure.Mobile.Server/Config/MobileAppControllerAttribute.cs
+++ b/src/Microsoft.Azure.Mobile.Server/Config/MobileAppControllerAttribute.cs
@@ -42,34 +42,13 @@ namespace Microsoft.Azure.Mobile.Server.Config
         /// <inheritdoc />
         public virtual void Initialize(HttpControllerSettings controllerSettings, HttpControllerDescriptor controllerDescriptor)
         {
-            if (controllerSettings == null)
+            if (controllerDescriptor == null)
             {
-                throw new ArgumentNullException("controllerSettings");
+                throw new ArgumentNullException("controllerDescriptor");
             }
 
-            JsonMediaTypeFormatter jsonFormatter = new JsonMediaTypeFormatter();
-            JsonSerializerSettings serializerSettings = jsonFormatter.SerializerSettings;
-
-            // Set up date/time format to be ISO 8601 but with 3 digits and "Z" as UTC time indicator. This format
-            // is the JS-valid format accepted by most JS clients.
-            IsoDateTimeConverter dateTimeConverter = new IsoDateTimeConverter()
-            {
-                Culture = CultureInfo.InvariantCulture,
-                DateTimeFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFZ",
-                DateTimeStyles = DateTimeStyles.AdjustToUniversal
-            };
-
-            // Ignoring default values while serializing was affecting offline scenarios as client sdk looks at first object in a batch for the properties.
-            // If first row in the server response did not include columns with default values, client sdk ignores these columns for the rest of the rows
-            serializerSettings.DefaultValueHandling = DefaultValueHandling.Include;
-            serializerSettings.NullValueHandling = NullValueHandling.Include;
-            serializerSettings.Converters.Add(new StringEnumConverter());
-            serializerSettings.Converters.Add(dateTimeConverter);
-            serializerSettings.MissingMemberHandling = MissingMemberHandling.Error;
-            serializerSettings.CheckAdditionalContent = true;
-            serializerSettings.ContractResolver = new ServiceContractResolver(jsonFormatter);
-            controllerSettings.Formatters.Remove(controllerSettings.Formatters.JsonFormatter);
-            controllerSettings.Formatters.Insert(0, jsonFormatter);
+            IMobileAppControllerConfigProvider configurationProvider = controllerDescriptor.Configuration.GetMobileAppControllerConfigProvider();
+            configurationProvider.Configure(controllerSettings, controllerDescriptor);
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.Azure.Mobile.Server/Config/MobileAppControllerConfigProvider.cs
+++ b/src/Microsoft.Azure.Mobile.Server/Config/MobileAppControllerConfigProvider.cs
@@ -1,0 +1,54 @@
+﻿// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+using System;
+using System.Globalization;
+using System.Net.Http.Formatting;
+using System.Web.Http.Controllers;
+using Microsoft.Azure.Mobile.Server.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Microsoft.Azure.Mobile.Server.Config
+{
+    /// <summary>
+    /// A default implementation of <see cref="IMobileAppControllerConfigProvider" /> that configures the JSON
+    /// serializer settings for use with Mobile App clients.
+    /// </summary>
+    public class MobileAppControllerConfigProvider : IMobileAppControllerConfigProvider
+    {
+        /// <inheritdoc />
+        public virtual void Configure(HttpControllerSettings controllerSettings, HttpControllerDescriptor controllerDescriptor)
+        {
+            if (controllerSettings == null)
+            {
+                throw new ArgumentNullException("controllerSettings");
+            }
+
+            JsonMediaTypeFormatter jsonFormatter = new JsonMediaTypeFormatter();
+            JsonSerializerSettings serializerSettings = jsonFormatter.SerializerSettings;
+
+            // Set up date/time format to be ISO 8601 but with 3 digits and "Z" as UTC time indicator. This format
+            // is the JS-valid format accepted by most JS clients.
+            IsoDateTimeConverter dateTimeConverter = new IsoDateTimeConverter()
+            {
+                Culture = CultureInfo.InvariantCulture,
+                DateTimeFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFZ",
+                DateTimeStyles = DateTimeStyles.AdjustToUniversal
+            };
+
+            // Ignoring default values while serializing was affecting offline scenarios as client sdk looks at first object in a batch for the properties.
+            // If first row in the server response did not include columns with default values, client sdk ignores these columns for the rest of the rows
+            serializerSettings.DefaultValueHandling = DefaultValueHandling.Include;
+            serializerSettings.NullValueHandling = NullValueHandling.Include;
+            serializerSettings.Converters.Add(new StringEnumConverter());
+            serializerSettings.Converters.Add(dateTimeConverter);
+            serializerSettings.MissingMemberHandling = MissingMemberHandling.Error;
+            serializerSettings.CheckAdditionalContent = true;
+            serializerSettings.ContractResolver = new ServiceContractResolver(jsonFormatter);
+            controllerSettings.Formatters.Remove(controllerSettings.Formatters.JsonFormatter);
+            controllerSettings.Formatters.Insert(0, jsonFormatter);
+        }
+    }
+}

--- a/src/Microsoft.Azure.Mobile.Server/Extensions/HttpConfigurationExtensions.cs
+++ b/src/Microsoft.Azure.Mobile.Server/Extensions/HttpConfigurationExtensions.cs
@@ -20,6 +20,7 @@ namespace System.Web.Http
         private const string MobileAppOptionsKey = "MS_MobileAppOptions";
         private const string MobileAppSettingsProviderKey = "MS_MobileAppSettingsProvider";
         private const string CachePolicyProviderKey = "MS_CachePolicyProvider";
+        private const string MobileAppControllerConfigProviderKey = "MS_MobileAppControllerConfigProvider";
 
         /// <summary>
         /// Gets the <see cref="Microsoft.Azure.Mobile.Server.Config.MobileAppConfiguration"/> registered with the current <see cref="System.Web.Http.HttpConfiguration" />.
@@ -123,6 +124,44 @@ namespace System.Web.Http
             }
 
             config.Properties[CachePolicyProviderKey] = provider;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Microsoft.Azure.Mobile.Server.Config.IMobileAppControllerConfigProvider"/> registered with the current <see cref="System.Web.Http.HttpConfiguration" />.
+        /// </summary>
+        /// <param name="config">The current <see cref="System.Web.Http.HttpConfiguration"/>.</param>
+        /// <returns>The registered instance.</returns>
+        public static IMobileAppControllerConfigProvider GetMobileAppControllerConfigProvider(this HttpConfiguration config)
+        {
+            if (config == null)
+            {
+                throw new ArgumentNullException("config");
+            }
+
+            IMobileAppControllerConfigProvider provider = null;
+            if (!config.Properties.TryGetValue(MobileAppControllerConfigProviderKey, out provider))
+            {
+                provider = new MobileAppControllerConfigProvider();
+                config.Properties[MobileAppControllerConfigProviderKey] = provider;
+            }
+
+            return provider;
+        }
+
+        /// <summary>
+        /// Registers an <see cref="Microsoft.Azure.Mobile.Server.Config.IMobileAppControllerConfigProvider"/> with the current <see cref="System.Web.Http.HttpConfiguration" />.
+        /// The registered class provides the base settings for controllers using the <see cref="Microsoft.Azure.Mobile.Server.Config.MobileAppControllerAttribute" />.
+        /// </summary>
+        /// <param name="config">The current <see cref="System.Web.Http.HttpConfiguration"/>.</param>
+        /// <param name="configProvider">The instance to register.</param>
+        public static void SetMobileAppControllerConfigProvider(this HttpConfiguration config, IMobileAppControllerConfigProvider configProvider)
+        {
+            if (config == null)
+            {
+                throw new ArgumentNullException("config");
+            }
+
+            config.Properties[MobileAppControllerConfigProviderKey] = configProvider;
         }
 
         internal static HashSet<string> GetMobileAppControllerNames(this HttpConfiguration config)

--- a/src/Microsoft.Azure.Mobile.Server/Microsoft.Azure.Mobile.Server.csproj
+++ b/src/Microsoft.Azure.Mobile.Server/Microsoft.Azure.Mobile.Server.csproj
@@ -119,9 +119,11 @@
     <Compile Include="Cache\CachePolicyProvider.cs" />
     <Compile Include="Cache\ICachePolicyProvider.cs" />
     <Compile Include="Config\AppConfiguration.cs" />
+    <Compile Include="Config\IMobileAppControllerConfigProvider.cs" />
     <Compile Include="Config\IMobileAppExtensionConfigProvider.cs" />
     <Compile Include="Config\MobileAppControllerAttribute.cs" />
     <Compile Include="Config\MobileAppConfiguration.cs" />
+    <Compile Include="Config\MobileAppControllerConfigProvider.cs" />
     <Compile Include="Content\StaticHtmlActionResult.cs" />
     <Compile Include="Config\IAppConfiguration.cs" />
     <Compile Include="LogCategories.cs" />

--- a/test/Common/SerializationAssert.cs
+++ b/test/Common/SerializationAssert.cs
@@ -1,6 +1,6 @@
-﻿// ---------------------------------------------------------------------------- 
+﻿// ----------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// ---------------------------------------------------------------------------- 
+// ----------------------------------------------------------------------------
 
 using System.Collections.Generic;
 using System.Net.Http.Formatting;
@@ -24,7 +24,11 @@ namespace Microsoft.Azure.Mobile
             var config = new HttpConfiguration();
             var controllerSettings = new HttpControllerSettings(config);
             var mobileAppControllerConfig = new MobileAppControllerAttribute();
-            mobileAppControllerConfig.Initialize(controllerSettings, new HttpControllerDescriptor());
+            var controllerDescriptor = new HttpControllerDescriptor()
+            {
+                Configuration = config
+            };
+            mobileAppControllerConfig.Initialize(controllerSettings, controllerDescriptor);
 
             JsonMediaTypeFormatter jsonFormatter = controllerSettings.Formatters.JsonFormatter;
             JsonSerializerSettings settings = jsonFormatter.SerializerSettings;

--- a/test/Microsoft.Azure.Mobile.Server.Authentication.Test/Controllers/SecuredControllerTests.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Authentication.Test/Controllers/SecuredControllerTests.cs
@@ -250,8 +250,6 @@ namespace Microsoft.Azure.Mobile.Server
 
             private AppServiceAuthenticationOptions GetMobileAppAuthOptions(HttpConfiguration config)
             {
-                MobileAppSettingsDictionary settings = config.GetMobileAppSettingsProvider().GetMobileAppSettings();
-
                 return new AppServiceAuthenticationOptions
                 {
                     SigningKey = this.SigningKey,

--- a/test/Microsoft.Azure.Mobile.Server.Authentication.Test/MobileAppAuthenticationHandlerTests.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Authentication.Test/MobileAppAuthenticationHandlerTests.cs
@@ -227,8 +227,6 @@ namespace Microsoft.Azure.Mobile.Server.Security
 
         private static IOwinRequest CreateAuthRequest(Uri webappUri, JwtSecurityToken token = null)
         {
-            string webappBaseUrl = webappUri.GetLeftPart(UriPartial.Authority) + "/";
-
             OwinContext context = new OwinContext();
             IOwinRequest request = context.Request;
             request.Host = HostString.FromUriComponent(webappUri.Host);

--- a/test/Microsoft.Azure.Mobile.Server.CrossDomain.Test/Controllers/CrossDomainControllerTests.cs
+++ b/test/Microsoft.Azure.Mobile.Server.CrossDomain.Test/Controllers/CrossDomainControllerTests.cs
@@ -1,6 +1,6 @@
-﻿// ---------------------------------------------------------------------------- 
+﻿// ----------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// ---------------------------------------------------------------------------- 
+// ----------------------------------------------------------------------------
 
 using System.Collections.Generic;
 using System.Net;
@@ -32,10 +32,10 @@ namespace Microsoft.Azure.Mobile.Server.Controllers
             get
             {
                 return new TheoryDataCollection<string[]>
-                {                    
-                    { new string[] { "http://A", "https://B", "http://C" } },                
+                {
+                    { new string[] { "http://A", "https://B", "http://C" } },
                     { new string[] { "http://你好.com", "http://世界.com" } },
-                    { new string[] { "http://testhost", "http://sample" } } 
+                    { new string[] { "http://testhost", "http://sample" } }
                 };
             }
         }
@@ -145,6 +145,7 @@ namespace Microsoft.Azure.Mobile.Server.Controllers
         {
             // Arrange
             HttpConfiguration config = new HttpConfiguration();
+            CrossDomainController.Reset();
             new MobileAppConfiguration()
                 .MapLegacyCrossDomainController(origins)
                 .ApplyTo(config);
@@ -163,6 +164,7 @@ namespace Microsoft.Azure.Mobile.Server.Controllers
         public async Task DirectOrigins_Wins_IfGlobalAlsoSet()
         {
             // Arrange
+            CrossDomainController.Reset();
             HttpConfiguration config = new HttpConfiguration();
 
             new MobileAppConfiguration()
@@ -185,8 +187,8 @@ namespace Microsoft.Azure.Mobile.Server.Controllers
         public async Task OriginsCache_Null_IfNoOriginsSet()
         {
             // Arrange
+            CrossDomainController.Reset();
             HttpConfiguration config = new HttpConfiguration();
-
             new MobileAppConfiguration()
                 .MapLegacyCrossDomainController()
                 .ApplyTo(config);
@@ -205,7 +207,7 @@ namespace Microsoft.Azure.Mobile.Server.Controllers
         [Fact]
         public async Task InitializeOrigins_ReturnsCachedList()
         {
-            // Arrange            
+            // Arrange
             HttpConfiguration config = new HttpConfiguration();
             config.EnableCors(new EnableCorsAttribute("http://test", "*", "*"));
             HttpRequestMessage request = new HttpRequestMessage();
@@ -223,6 +225,7 @@ namespace Microsoft.Azure.Mobile.Server.Controllers
         {
             HttpConfiguration config = new HttpConfiguration();
             MobileAppConfiguration mobileConfig = new MobileAppConfiguration();
+            CrossDomainController.Reset();
 
             if (origins == null)
             {

--- a/test/Microsoft.Azure.Mobile.Server.CrossDomain.Test/Extensions/MobileAppExtensionsTests.cs
+++ b/test/Microsoft.Azure.Mobile.Server.CrossDomain.Test/Extensions/MobileAppExtensionsTests.cs
@@ -1,9 +1,16 @@
-﻿// ---------------------------------------------------------------------------- 
+﻿// ----------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// ---------------------------------------------------------------------------- 
+// ----------------------------------------------------------------------------
 
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
 using System.Web.Http;
 using Microsoft.Azure.Mobile.Server.Config;
+using Microsoft.Azure.Mobile.Server.Controllers;
+using Microsoft.Owin.Testing;
+using Owin;
 using Xunit;
 
 namespace Microsoft.Azure.Mobile.Server.CrossDomain.Test.Extensions
@@ -14,6 +21,8 @@ namespace Microsoft.Azure.Mobile.Server.CrossDomain.Test.Extensions
         public void MapLegacyCrossDomainController_SetsCrossDomainOrigins()
         {
             // Arrange
+            CrossDomainController.Reset();
+
             var origins = new[] { "a", "b" };
             HttpConfiguration config = new HttpConfiguration();
 
@@ -25,6 +34,41 @@ namespace Microsoft.Azure.Mobile.Server.CrossDomain.Test.Extensions
             // Assert
             var actual = config.GetCrossDomainOrigins();
             Assert.Same(origins, actual);
+        }
+
+        [Fact]
+        public async Task MapLegacyCrossDomainController_MapsRoutesCorrectly()
+        {
+            // Arrange
+            CrossDomainController.Reset();
+
+            TestServer server = TestServer.Create(app =>
+            {
+                HttpConfiguration config = new HttpConfiguration();
+                new MobileAppConfiguration()
+                    .MapApiControllers()
+                    .MapLegacyCrossDomainController(new[] { "testorigin" })
+                    .ApplyTo(config);
+
+                app.UseWebApi(config);
+            });
+
+            HttpClient client = server.HttpClient;
+
+            // Act
+            var getBridge = await client.GetAsync("crossdomain/bridge?origin=testorigin");
+            var getLoginReceiver = await client.GetAsync("crossdomain/loginreceiver?completion_origin=testorigin");
+
+            var getBridgeApi = await client.GetAsync("api/crossdomain/bridge?origin=testorigin");
+            var getLoginReceiverApi = await client.GetAsync("api/crossdomain/loginreceiver?completion_origin=testorigin");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, getBridge.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, getLoginReceiver.StatusCode);
+
+            // api routes should not be found
+            Assert.Equal(HttpStatusCode.NotFound, getBridgeApi.StatusCode);
+            Assert.Equal(HttpStatusCode.NotFound, getLoginReceiverApi.StatusCode);
         }
     }
 }

--- a/test/Microsoft.Azure.Mobile.Server.Login.Test/AppServiceLoginHandlerTests.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Login.Test/AppServiceLoginHandlerTests.cs
@@ -62,20 +62,15 @@ namespace Microsoft.Azure.Mobile.Server.Login.Test
                 new Claim(JwtRegisteredClaimNames.Sub, UserId)
             };
 
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() =>
+            Assert.Throws<ArgumentNullException>(() =>
                 AppServiceLoginHandler.CreateToken(claims, null, Audience, Issuer, TimeSpan.FromDays(10)));
         }
 
         [Fact]
         public void CreateToken_Throws_IfClaimsNull()
         {
-            Claim[] claims = new Claim[]
-            {
-                new Claim(JwtRegisteredClaimNames.Sub, UserId)
-            };
-
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() =>
-                AppServiceLoginHandler.CreateToken(null, SigningKey, Audience, Issuer, TimeSpan.FromDays(10)));
+            Assert.Throws<ArgumentNullException>(() =>
+                  AppServiceLoginHandler.CreateToken(null, SigningKey, Audience, Issuer, TimeSpan.FromDays(10)));
         }
 
         [Fact]

--- a/test/Microsoft.Azure.Mobile.Server.Notifications.Test/Extensions/MobileAppExtensionsTests.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Notifications.Test/Extensions/MobileAppExtensionsTests.cs
@@ -1,0 +1,83 @@
+﻿// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading.Tasks;
+using System.Web.Http;
+using Microsoft.Azure.Mobile.Server.Config;
+using Microsoft.Azure.NotificationHubs;
+using Microsoft.Azure.NotificationHubs.Messaging;
+using Microsoft.Owin.Testing;
+using Moq;
+using Owin;
+using Xunit;
+
+namespace Microsoft.Azure.Mobile.Server.Notifications.Test.Extensions
+{
+    public class MobileAppExtensionsTests
+    {
+        [Fact]
+        public async Task MapLegacyCrossDomainController_MapsRoutesCorrectly()
+        {
+            // Arrange
+            NotificationInstallation notification = new NotificationInstallation();
+            notification.InstallationId = Guid.NewGuid().ToString();
+            notification.PushChannel = Guid.NewGuid().ToString();
+            notification.Platform = "wns";
+
+            TestServer server = TestServer.Create(app =>
+            {
+                HttpConfiguration config = new HttpConfiguration();
+
+                var pushClientMock = new Mock<PushClient>(config);
+                pushClientMock.Setup(p => p.CreateOrUpdateInstallationAsync(It.IsAny<Installation>()))
+                    .Returns(Task.FromResult(0));
+                pushClientMock.Setup(p => p.GetRegistrationsByTagAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()))
+                    .Returns(Task.FromResult(this.CreateCollectionQueryResult<RegistrationDescription>()));
+                pushClientMock.Setup(p => p.DeleteInstallationAsync(It.IsAny<string>()))
+                    .Returns(Task.FromResult(0));
+
+                config.SetPushClient(pushClientMock.Object);
+
+                new MobileAppConfiguration()
+                    .MapApiControllers()
+                    .AddPushNotifications()
+                    .ApplyTo(config);
+
+                app.UseWebApi(config);
+            });
+
+            HttpClient client = server.HttpClient;
+            client.DefaultRequestHeaders.Add("ZUMO-API-VERSION", "2.0.0");
+
+            // Act
+            var notificationsPut = await client.PutAsJsonAsync("push/installations/" + notification.InstallationId, notification);
+            var notificationsDelete = await client.DeleteAsync("push/installations/" + notification.InstallationId);
+
+            var notificationsPutApi = await client.PutAsJsonAsync("api/NotificationInstallations?installationId=" + notification.InstallationId, notification);
+            var notificationsDeleteApi = await client.DeleteAsync("api/NotificationInstallations?installationId=" + notification.InstallationId);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, notificationsPut.StatusCode);
+            Assert.Equal(HttpStatusCode.NoContent, notificationsDelete.StatusCode);
+
+            // api routes should not be found
+            Assert.Equal(HttpStatusCode.NotFound, notificationsPutApi.StatusCode);
+            Assert.Equal(HttpStatusCode.NotFound, notificationsDeleteApi.StatusCode);
+        }
+
+        // CollectionQueryResult is internal so we need to use reflection to make one for mocking purposes.
+        private CollectionQueryResult<T> CreateCollectionQueryResult<T>() where T : EntityDescription
+        {
+            var constructor = typeof(CollectionQueryResult<T>)
+                .GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance)
+                .Single();
+            return constructor.Invoke(new object[] { null, null }) as CollectionQueryResult<T>;
+        }
+    }
+}

--- a/test/Microsoft.Azure.Mobile.Server.Notifications.Test/Microsoft.Azure.Mobile.Server.Notifications.Test.csproj
+++ b/test/Microsoft.Azure.Mobile.Server.Notifications.Test/Microsoft.Azure.Mobile.Server.Notifications.Test.csproj
@@ -127,6 +127,7 @@
     </Compile>
     <Compile Include="ApplePushMessageTests.cs" />
     <Compile Include="Controllers\NotificationInstallationsControllerTests.cs" />
+    <Compile Include="Extensions\MobileAppExtensionsTests.cs" />
     <Compile Include="GooglePushMessageTests.cs" />
     <Compile Include="MpnsPushMessageTests.cs" />
     <Compile Include="Notifications\AlertPropertiesTests.cs" />

--- a/test/Microsoft.Azure.Mobile.Server.Quickstart.Test/Config/MobileAppConfigSetupTests.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Quickstart.Test/Config/MobileAppConfigSetupTests.cs
@@ -96,8 +96,10 @@ namespace Microsoft.Azure.Mobile.Server.Config
                 var tableGet = await client.GetAsync("tables/testtable");
                 var tableGetApplication = await client.GetAsync("tables/testtable/someId");
                 var tableGetApiRoute = await client.GetAsync("api/testtable");
-                var apiGetAnonymous = await client.GetAsync("api/secured/anonymous");
-                var apiGetAuthorize = await client.GetAsync("api/secured/authorize");
+                var apiGetAnonymous = await client.GetAsync("auth/anonymous");
+                var apiGetAuthorize = await client.GetAsync("auth/authorize");
+                var apiDirectRoute = await client.GetAsync("api/testapi");
+                var apiGetTableRoute = await client.GetAsync("table/testapi");
 
                 // Assert
                 Assert.Equal(HttpStatusCode.OK, notificationsPut.StatusCode);
@@ -115,17 +117,23 @@ namespace Microsoft.Azure.Mobile.Server.Config
                 ValidateHeaders(tableGetApplication, true);
 
                 // Succeeds: TableControllers will show up in the api route as well.
-                Assert.Equal(HttpStatusCode.OK, tableGetApiRoute.StatusCode);
+                Assert.Equal(HttpStatusCode.NotFound, tableGetApiRoute.StatusCode);
                 ValidateHeaders(tableGetApiRoute, true);
 
-                // Succeeds: Auth is not set up so no ServiceUser is created. But
-                // the AuthorizeAttribute lets these through.
+                // Succeeds: Auth is not set up so no IPrincipal is created. But
+                // the AllowAnonymousAttribute lets these through.
                 Assert.Equal(HttpStatusCode.OK, apiGetAnonymous.StatusCode);
                 ValidateHeaders(apiGetAnonymous, false);
 
-                // Succeeds: Api action with no AuthorizeLevel attribute
+                Assert.Equal(HttpStatusCode.OK, apiDirectRoute.StatusCode);
+                ValidateHeaders(apiDirectRoute, true);
+
+                Assert.Equal(HttpStatusCode.NotFound, apiGetTableRoute.StatusCode);
+                ValidateHeaders(apiGetTableRoute, true);
+
                 Assert.Equal(isAuthenticated ? HttpStatusCode.OK : HttpStatusCode.Unauthorized, apiGetAuthorize.StatusCode);
                 ValidateHeaders(apiGetAuthorize, false);
+
                 if (isAuthenticated)
                 {
                     string requestAuthToken = apiGetAuthorize.RequestMessage.Headers.Single(h => h.Key == "x-zumo-auth").Value.Single();

--- a/test/Microsoft.Azure.Mobile.Server.Quickstart.Test/Microsoft.Azure.Mobile.Server.Quickstart.Test.csproj
+++ b/test/Microsoft.Azure.Mobile.Server.Quickstart.Test/Microsoft.Azure.Mobile.Server.Quickstart.Test.csproj
@@ -142,6 +142,7 @@
     <Compile Include="Config\MobileAppAppBuilderExtensionTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestControllers\SecuredController.cs" />
+    <Compile Include="TestControllers\TestApiController.cs" />
     <Compile Include="TestControllers\TestTableController.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Microsoft.Azure.Mobile.Server.Quickstart.Test/TestControllers/SecuredController.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Quickstart.Test/TestControllers/SecuredController.cs
@@ -1,10 +1,12 @@
-﻿// ---------------------------------------------------------------------------- 
+﻿// ----------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// ---------------------------------------------------------------------------- 
+// ----------------------------------------------------------------------------
 
 using System.Linq;
+using System.Net.Http;
 using System.Security.Claims;
 using System.Web.Http;
+using Microsoft.Azure.Mobile.Server.Config;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.Mobile.Server.TestControllers
@@ -13,14 +15,16 @@ namespace Microsoft.Azure.Mobile.Server.TestControllers
     public class SecuredController : ApiController
     {
         [AllowAnonymous]
-        [Route("api/secured/anonymous")]
-        public IHttpActionResult GetAnonymous()
+        [Route("auth/anonymous")]
+        [HttpGet]
+        public IHttpActionResult AuthNotRequired()
         {
             return this.GetUserDetails();
         }
 
-        [Route("api/secured/authorize")]
-        public string GetApplication()
+        [Route("auth/authorize")]
+        [HttpGet]
+        public string AuthRequired()
         {
             return this.Request.Headers.GetValues("x-zumo-auth").FirstOrDefault<string>();
         }
@@ -39,7 +43,7 @@ namespace Microsoft.Azure.Mobile.Server.TestControllers
                 }
                 details = new JObject
                 {
-                    { "id", userId }               
+                    { "id", userId }
                 };
             }
 

--- a/test/Microsoft.Azure.Mobile.Server.Quickstart.Test/TestControllers/TestApiController.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Quickstart.Test/TestControllers/TestApiController.cs
@@ -1,0 +1,19 @@
+﻿// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+using System.Web.Http;
+using Microsoft.Azure.Mobile.Server.Config;
+
+namespace Microsoft.Azure.Mobile.Server.Quickstart.Test.TestControllers
+{
+    [MobileAppController]
+    public class TestApiController : ApiController
+    {
+        [HttpGet]
+        public string NoAttribute()
+        {
+            return "Hello";
+        }
+    }
+}

--- a/test/Microsoft.Azure.Mobile.Server.Tables.Test/Extensions/MobileAppConfigurationExtensionsTests.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Tables.Test/Extensions/MobileAppConfigurationExtensionsTests.cs
@@ -1,0 +1,172 @@
+﻿// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Web.Http;
+using System.Web.Http.Controllers;
+using System.Web.Http.Dispatcher;
+using Microsoft.Azure.Mobile.Server;
+using Microsoft.Azure.Mobile.Server.Config;
+using Microsoft.Azure.Mobile.Server.Tables;
+using Microsoft.Owin.Testing;
+using Moq;
+using Owin;
+using Xunit;
+
+namespace Microsoft.Azure.Mobile.Server.Extensions
+{
+    public class MobileAppConfigurationExtensionsTests
+    {
+        [Fact]
+        public void WithTableControllerConfigProvider_AddsProvider()
+        {
+            // Arrange
+            HttpConfiguration config = new HttpConfiguration();
+            var provider = new Mock<ITableControllerConfigProvider>();
+
+            // Act
+            new MobileAppConfiguration()
+                .WithTableControllerConfigProvider(provider.Object)
+                .ApplyTo(config);
+
+            // Assert
+            Assert.Same(provider.Object, config.GetTableControllerConfigProvider());
+        }
+
+        [Fact]
+        public async Task WithTableControllerConfigProvider_RegistersProviderCorrectly()
+        {
+            // Arrange
+            string output = string.Empty;
+            var providerMock = new Mock<IMobileAppControllerConfigProvider>();
+            providerMock.Setup(p => p.Configure(It.IsAny<HttpControllerSettings>(), It.IsAny<HttpControllerDescriptor>()))
+                .Callback(() => output += "1");
+            var tableProviderMock = new Mock<ITableControllerConfigProvider>();
+            tableProviderMock.Setup(p => p.Configure(It.IsAny<HttpControllerSettings>(), It.IsAny<HttpControllerDescriptor>()))
+                .Callback(() => output += "2");
+
+            HttpConfiguration config = new HttpConfiguration();
+
+            var server = TestServer.Create(app =>
+            {
+                // mock out the controller discovery to only find these
+                var controllerTypesToReturn = new[]
+                {
+                    typeof(MyTable1Controller),
+                    typeof(MyTable2Controller)
+                };
+
+                SetupMockControllerResolver(config, controllerTypesToReturn);
+
+                new MobileAppConfiguration()
+                    .WithTableControllerConfigProvider(tableProviderMock.Object)
+                    .WithMobileAppControllerConfigProvider(providerMock.Object)
+                    .AddTables()
+                    .ApplyTo(config);
+
+                app.UseWebApi(config);
+            });
+
+            var client = server.HttpClient;
+            client.DefaultRequestHeaders.Add("ZUMO-API-VERSION", "2.0.0");
+
+            // Act
+            // issue a request to initialize the config
+            var result = await client.GetAsync("tables/mytable1");
+
+            // Assert
+            Assert.Same(providerMock.Object, config.GetMobileAppControllerConfigProvider());
+            Assert.Same(tableProviderMock.Object, config.GetTableControllerConfigProvider());
+            // each provider should be called once for each TableController, in order.
+            Assert.Equal("1212", output);
+        }
+
+        [Fact]
+        public async Task AddTables_MapsRoutesCorrectly()
+        {
+            // Arrange
+            TestServer server = TestServer.Create(app =>
+            {
+                HttpConfiguration config = new HttpConfiguration();
+
+                // mock out the controller discovery to only find these
+                var controllerTypesToReturn = new[]
+                {
+                    typeof(MyCustomController),
+                    typeof(MyTable1Controller),
+                    typeof(MyTable2Controller)
+                };
+
+                SetupMockControllerResolver(config, controllerTypesToReturn);
+
+                new MobileAppConfiguration()
+                    .MapApiControllers()
+                    .AddTables()
+                    .ApplyTo(config);
+
+                app.UseWebApi(config);
+            });
+
+            HttpClient client = server.HttpClient;
+            client.DefaultRequestHeaders.Add("ZUMO-API-VERSION", "2.0.0");
+
+            // Act
+            var getTable1 = await client.GetAsync("tables/mytable1");
+            var getTable2 = await client.GetAsync("tables/mytable2");
+            var getApi = await client.GetAsync("api/mycustom");
+
+            var getTable1AsApi = await client.GetAsync("api/mytable1");
+            var getTable2AsApi = await client.GetAsync("api/mytable2");
+            var getApiAsTable = await client.GetAsync("tables/mycustom");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, getTable1.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, getTable2.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, getApi.StatusCode);
+
+            // api routes should not be found
+            Assert.Equal(HttpStatusCode.NotFound, getTable1AsApi.StatusCode);
+            Assert.Equal(HttpStatusCode.NotFound, getTable2AsApi.StatusCode);
+            Assert.Equal(HttpStatusCode.NotFound, getApiAsTable.StatusCode);
+        }
+
+        private static void SetupMockControllerResolver(HttpConfiguration config, ICollection<Type> controllerTypesToReturn)
+        {
+            IAssembliesResolver assemblyResolver = config.Services.GetAssembliesResolver();
+            Mock<IHttpControllerTypeResolver> typeResolverMock = new Mock<IHttpControllerTypeResolver>();
+            typeResolverMock.Setup(m => m.GetControllerTypes(assemblyResolver)).Returns(controllerTypesToReturn);
+
+            config.Services.Replace(typeof(IHttpControllerTypeResolver), typeResolverMock.Object);
+        }
+
+        [MobileAppController]
+        private class MyCustomController : ApiController
+        {
+            public IHttpActionResult Get()
+            {
+                return this.Ok();
+            }
+        }
+
+        private class MyTable1Controller : TableController
+        {
+            public IHttpActionResult Get()
+            {
+                return this.Ok();
+            }
+        }
+
+        private class MyTable2Controller : TableController
+        {
+            public IHttpActionResult Get()
+            {
+                return this.Ok();
+            }
+        }
+    }
+}

--- a/test/Microsoft.Azure.Mobile.Server.Tables.Test/Extensions/TableHttpConfigurationExtensionTests.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Tables.Test/Extensions/TableHttpConfigurationExtensionTests.cs
@@ -1,0 +1,98 @@
+﻿// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+using System.Web.Http;
+using System.Web.Http.Dispatcher;
+using Microsoft.Azure.Mobile.Server.Config;
+using Microsoft.Azure.Mobile.Server.Tables;
+using Microsoft.Azure.Mobile.Server.TestControllers;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.Mobile.Server.Extensions
+{
+    public class TableHttpConfigurationExtensionTests
+    {
+        [Fact]
+        public void GetTableControllerConfigProvider_ReturnsDefaultInstance()
+        {
+            // Arrange
+            HttpConfiguration config = new HttpConfiguration();
+
+            // Act
+            ITableControllerConfigProvider actual = config.GetTableControllerConfigProvider();
+
+            // Assert
+            Assert.NotNull(actual);
+            Assert.IsType<TableControllerConfigProvider>(actual);
+        }
+
+        [Fact]
+        public void SetMobileAppControllerConfigProvider_Roundtrips()
+        {
+            // Arrange
+            TableControllerConfigProvider provider = new TableControllerConfigProvider();
+            HttpConfiguration config = new HttpConfiguration();
+
+            // Act
+            config.SetTableControllerConfigProvider(provider);
+            ITableControllerConfigProvider actual = config.GetTableControllerConfigProvider();
+
+            // Assert
+            Assert.Same(provider, actual);
+        }
+
+        [Fact]
+        public void SetMobileAppControllerConfigProvider_ReturnsDefault_IfSetToNull()
+        {
+            // Arrange
+            HttpConfiguration config = new HttpConfiguration();
+
+            // Act
+            config.SetMobileAppControllerConfigProvider(null);
+            ITableControllerConfigProvider actual = config.GetTableControllerConfigProvider();
+
+            // Assert
+            Assert.NotNull(actual);
+            Assert.IsType<TableControllerConfigProvider>(actual);
+        }
+
+        [Fact]
+        public void GetTableControllerNames_ReturnsCorrectControllers()
+        {
+            // Arrange
+            var typeList = new[]
+            {
+                typeof(MoviesController),
+                typeof(ZetaController),
+                typeof(TestTableController),
+                typeof(ApiController),
+                typeof(CustomController),
+                typeof(DerivedMoviesController)
+            };
+
+            HttpConfiguration config = new HttpConfiguration();
+            IAssembliesResolver assemblyResolver = config.Services.GetAssembliesResolver();
+            Mock<IHttpControllerTypeResolver> typeResolverMock = new Mock<IHttpControllerTypeResolver>();
+            typeResolverMock.Setup(m => m.GetControllerTypes(assemblyResolver)).Returns(typeList);
+
+            config.Services.Replace(typeof(IHttpControllerTypeResolver), typeResolverMock.Object);
+
+            // Act
+            var names = config.GetTableControllerNames();
+
+            // Assert
+            Assert.Equal(new[] { "Movies", "TestTable", "DerivedMovies" }, names);
+        }
+
+        private class DerivedMoviesController : MoviesController
+        {
+        }
+
+        [MobileAppController]
+        private class CustomController : ApiController
+        {
+        }
+    }
+}

--- a/test/Microsoft.Azure.Mobile.Server.Tables.Test/Microsoft.Azure.Mobile.Server.Tables.Test.csproj
+++ b/test/Microsoft.Azure.Mobile.Server.Tables.Test/Microsoft.Azure.Mobile.Server.Tables.Test.csproj
@@ -188,6 +188,8 @@
     <Compile Include="Controllers\EntityTableControllerQueryTests.cs" />
     <Compile Include="Controllers\MappedEntityTableControllerUpdateTests.cs" />
     <Compile Include="Controllers\VersionTableControllerTests.cs" />
+    <Compile Include="Extensions\MobileAppConfigurationExtensionsTests.cs" />
+    <Compile Include="Extensions\TableHttpConfigurationExtensionTests.cs" />
     <Compile Include="Extensions\TableHttpRequestMessageExtensionsTests.cs" />
     <Compile Include="Extensions\TableTypeExtensionsTests.cs" />
     <Compile Include="Headers\LinkHeaderTests.cs" />
@@ -199,6 +201,7 @@
     <Compile Include="Tables\QueryResultTests.cs" />
     <Compile Include="Tables\TableColumnAttributeTests.cs" />
     <Compile Include="Tables\TableControllerConfigAttributeTests.cs" />
+    <Compile Include="Tables\TableControllerConfigProviderTests.cs" />
     <Compile Include="Tables\TableFilterProviderTests.cs" />
     <Compile Include="Tables\TableQueryFilterTests.cs" />
     <Compile Include="Tables\TableUtilsTests.cs" />

--- a/test/Microsoft.Azure.Mobile.Server.Tables.Test/Tables/TableControllerConfigProviderTests.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Tables.Test/Tables/TableControllerConfigProviderTests.cs
@@ -1,0 +1,39 @@
+﻿// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+using System.Linq;
+using System.Web.Http;
+using System.Web.Http.Controllers;
+using Microsoft.Azure.Mobile.Server.Serialization;
+using Microsoft.Azure.Mobile.Server.Tables;
+using Xunit;
+
+namespace Microsoft.Azure.Mobile.Server.Config
+{
+    public class TableControllerConfigProviderTests
+    {
+        [Fact]
+        public void TableConfigProvider_SettingsAreCorrect()
+        {
+            // Arrange
+            var config = new HttpConfiguration();
+            var configProvider = new TableControllerConfigProvider();
+            var settings = new HttpControllerSettings(config);
+            var descriptor = new HttpControllerDescriptor()
+            {
+                Configuration = config
+            };
+
+            // Act
+            configProvider.Configure(settings, descriptor);
+
+            // Assert
+            // Verify SerializerSettings are set up as we expect
+            Assert.Null(settings.Formatters.XmlFormatter);
+            var filterProvider = config.Services.GetFilterProviders().OfType<TableFilterProvider>();
+            Assert.NotNull(filterProvider);
+            Assert.IsType<TableContractResolver>(settings.Formatters.JsonFormatter.SerializerSettings.ContractResolver);
+        }
+    }
+}

--- a/test/Microsoft.Azure.Mobile.Server.Test/Config/MobileAppConfigurationTests.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Test/Config/MobileAppConfigurationTests.cs
@@ -1,0 +1,173 @@
+﻿// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Web.Http;
+using System.Web.Http.Controllers;
+using System.Web.Http.Dispatcher;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.Mobile.Server.Config
+{
+    public class MobileAppConfigurationTests
+    {
+        [Fact]
+        public void WithMobileAppControllerConfigProvider_Default_IsCorrect()
+        {
+            var config = new HttpConfiguration();
+            new MobileAppConfiguration()
+                .ApplyTo(config);
+
+            var provider = config.GetMobileAppControllerConfigProvider();
+            Assert.NotNull(provider);
+            Assert.IsType<MobileAppControllerConfigProvider>(provider);
+        }
+
+        [Fact]
+        public void WithMobileAppControllerConfigProvider_CanBeOverridden()
+        {
+            var config = new HttpConfiguration();
+            var myProvider = new MyProvider();
+            new MobileAppConfiguration()
+                .WithMobileAppControllerConfigProvider(myProvider)
+                .ApplyTo(config);
+
+            var provider = config.GetMobileAppControllerConfigProvider();
+            Assert.NotNull(provider);
+            Assert.Same(myProvider, provider);
+            Assert.IsType<MyProvider>(provider);
+        }
+
+        [Fact]
+        public void MapApiControllers_IsFalse_ByDefault()
+        {
+            // Arrange
+            var config = new HttpConfiguration();
+
+            // Act
+            new MobileAppConfiguration()
+                .ApplyTo(config);
+
+            // Assert
+            Assert.Empty(config.Routes);
+        }
+
+        [Fact]
+        public void MapApiControllers_AddsApiRoute_WithConstraint()
+        {
+            // Arrange
+            var typeList = new[]
+            {
+                typeof(Mobile1Controller),
+                typeof(Mobile2Controller),
+                typeof(Mobile3Controller)
+            };
+
+            HttpConfiguration config = new HttpConfiguration();
+            SetupMockControllerList(config, typeList);
+
+            // Act
+            new MobileAppConfiguration()
+                .MapApiControllers()
+                .ApplyTo(config);
+
+            // Assert
+            Assert.Equal(1, config.Routes.Count);
+
+            var route = config.Routes[0];
+            Assert.Equal("api/{controller}/{id}", route.RouteTemplate);
+            Assert.Equal(1, route.Constraints.Count);
+            var constraint = route.Constraints["controller"] as SetRouteConstraint<string>;
+            Assert.NotNull(constraint);
+            Assert.Equal(false, constraint.Excluded);
+            Assert.Equal(new[] { "Mobile1", "Mobile2", "Mobile3" }, constraint.Set);
+        }
+
+        [Fact]
+        public void MapApiControllers_AppliesControllerExclusions()
+        {
+            // Arrange
+            var typeList = new[]
+            {
+                typeof(Mobile1Controller),
+                typeof(Mobile2Controller),
+                typeof(Mobile3Controller)
+            };
+
+            HttpConfiguration config = new HttpConfiguration();
+            SetupMockControllerList(config, typeList);
+
+            // Act
+            var mobileAppConfig = new MobileAppConfiguration()
+                .MapApiControllers();
+
+            mobileAppConfig.AddBaseRouteExclusion("Mobile2");
+            // verify comparisons are case-insensitive
+            mobileAppConfig.AddBaseRouteExclusion("MOBILE3");
+            mobileAppConfig.ApplyTo(config);
+
+            // Assert
+            Assert.Equal(1, config.Routes.Count);
+
+            var route = config.Routes[0];
+            Assert.Equal("api/{controller}/{id}", route.RouteTemplate);
+            Assert.Equal(1, route.Constraints.Count);
+            var constraint = route.Constraints["controller"] as SetRouteConstraint<string>;
+            Assert.NotNull(constraint);
+            Assert.Equal(false, constraint.Excluded);
+            Assert.Equal(new[] { "Mobile1" }, constraint.Set);
+        }
+
+        [Fact]
+        public void AddBaseRouteExclusion_DoesNotThrow_IfDuplicateItemAdded()
+        {
+            // Act
+            var mobileAppConfig = new MobileAppConfiguration();
+            mobileAppConfig.AddBaseRouteExclusion("MobileApp");
+            mobileAppConfig.AddBaseRouteExclusion("MobileApp");
+            mobileAppConfig.AddBaseRouteExclusion("mobileapp");
+
+            // Assert
+            Assert.Equal(1, mobileAppConfig.BaseRouteConstraints.Count);
+
+            // verify that comparisons are case-insensitive
+            Assert.True(mobileAppConfig.BaseRouteConstraints.Contains("MobileApp"));
+            Assert.True(mobileAppConfig.BaseRouteConstraints.Contains("mobileapp"));
+            Assert.True(mobileAppConfig.BaseRouteConstraints.Contains("MOBILEAPP"));
+        }
+
+        private static void SetupMockControllerList(HttpConfiguration config, ICollection<Type> controllerTypesToReturn)
+        {
+            IAssembliesResolver assemblyResolver = config.Services.GetAssembliesResolver();
+            Mock<IHttpControllerTypeResolver> typeResolverMock = new Mock<IHttpControllerTypeResolver>();
+            typeResolverMock.Setup(m => m.GetControllerTypes(assemblyResolver)).Returns(controllerTypesToReturn);
+
+            config.Services.Replace(typeof(IHttpControllerTypeResolver), typeResolverMock.Object);
+        }
+
+        private class MyProvider : IMobileAppControllerConfigProvider
+        {
+            public void Configure(HttpControllerSettings controllerSettings, HttpControllerDescriptor controllerDescriptor)
+            {
+            }
+        }
+
+        [MobileAppController]
+        private class Mobile1Controller : ApiController
+        {
+        }
+
+        [MobileAppController]
+        private class Mobile2Controller : ApiController
+        {
+        }
+
+        [MobileAppController]
+        private class Mobile3Controller : ApiController
+        {
+        }
+    }
+}

--- a/test/Microsoft.Azure.Mobile.Server.Test/Config/MobileAppControllerConfigProviderTests.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Test/Config/MobileAppControllerConfigProviderTests.cs
@@ -1,0 +1,55 @@
+﻿// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+using System.Globalization;
+using System.Linq;
+using System.Web.Http;
+using System.Web.Http.Controllers;
+using Microsoft.Azure.Mobile.Server.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Xunit;
+
+namespace Microsoft.Azure.Mobile.Server.Config
+{
+    public class MobileAppControllerConfigProviderTests
+    {
+        [Fact]
+        public void ConfigProvider_SettingsAreCorrect()
+        {
+            // Arrange
+            var config = new HttpConfiguration();
+            var configProvider = new MobileAppControllerConfigProvider();
+            var settings = new HttpControllerSettings(config);
+            var descriptor = new HttpControllerDescriptor()
+            {
+                Configuration = config
+            };
+
+            // Act
+            configProvider.Configure(settings, descriptor);
+
+            // Assert
+            // Verify SerializerSettings are set up as we expect
+            var serializerSettings = settings.Formatters.JsonFormatter.SerializerSettings;
+            Assert.Equal(typeof(ServiceContractResolver), serializerSettings.ContractResolver.GetType());
+            Assert.Equal(DefaultValueHandling.Include, serializerSettings.DefaultValueHandling);
+            Assert.Equal(NullValueHandling.Include, serializerSettings.NullValueHandling);
+            Assert.Equal(MissingMemberHandling.Error, serializerSettings.MissingMemberHandling);
+            Assert.True(serializerSettings.CheckAdditionalContent);
+
+            // Verify Converters
+            var stringEnumConverter = serializerSettings.Converters.Single(c => c.GetType() == typeof(StringEnumConverter)) as StringEnumConverter;
+            Assert.False(stringEnumConverter.CamelCaseText);
+
+            var isoDateTimeConverter = serializerSettings.Converters.Single(c => c.GetType() == typeof(IsoDateTimeConverter)) as IsoDateTimeConverter;
+            Assert.Equal(DateTimeStyles.AdjustToUniversal, isoDateTimeConverter.DateTimeStyles);
+            Assert.Equal("yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFZ", isoDateTimeConverter.DateTimeFormat);
+            Assert.Equal(CultureInfo.InvariantCulture, isoDateTimeConverter.Culture);
+
+            Assert.NotSame(config.Formatters.JsonFormatter.SerializerSettings.ContractResolver, settings.Formatters.JsonFormatter.SerializerSettings.ContractResolver);
+            Assert.Same(settings.Formatters.JsonFormatter, settings.Formatters[0]);
+        }
+    }
+}

--- a/test/Microsoft.Azure.Mobile.Server.Test/Extensions/HttpConfigurationExtensionsTests.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Test/Extensions/HttpConfigurationExtensionsTests.cs
@@ -2,8 +2,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // ----------------------------------------------------------------------------
 
+using System.Web.Http.Dispatcher;
 using Microsoft.Azure.Mobile.Server.Cache;
 using Microsoft.Azure.Mobile.Server.Config;
+using Microsoft.Azure.Mobile.Server.TestControllers;
+using Moq;
 using Xunit;
 
 namespace System.Web.Http
@@ -138,6 +141,94 @@ namespace System.Web.Http
             // Assert
             Assert.NotNull(actual);
             Assert.IsType<CachePolicyProvider>(actual);
+        }
+
+        [Fact]
+        public void GetMobileAppControllerConfigProvider_ReturnsDefaultInstance()
+        {
+            // Arrange
+            HttpConfiguration config = new HttpConfiguration();
+
+            // Act
+            IMobileAppControllerConfigProvider actual = config.GetMobileAppControllerConfigProvider();
+
+            // Assert
+            Assert.NotNull(actual);
+            Assert.IsType<MobileAppControllerConfigProvider>(actual);
+        }
+
+        [Fact]
+        public void SetMobileAppControllerConfigProvider_Roundtrips()
+        {
+            // Arrange
+            MobileAppControllerConfigProvider provider = new MobileAppControllerConfigProvider();
+            HttpConfiguration config = new HttpConfiguration();
+
+            // Act
+            config.SetMobileAppControllerConfigProvider(provider);
+            IMobileAppControllerConfigProvider actual = config.GetMobileAppControllerConfigProvider();
+
+            // Assert
+            Assert.Same(provider, actual);
+        }
+
+        [Fact]
+        public void SetMobileAppControllerConfigProvider_ReturnsDefault_IfSetToNull()
+        {
+            // Arrange
+            HttpConfiguration config = new HttpConfiguration();
+
+            // Act
+            config.SetMobileAppControllerConfigProvider(null);
+            IMobileAppControllerConfigProvider actual = config.GetMobileAppControllerConfigProvider();
+
+            // Assert
+            Assert.NotNull(actual);
+            Assert.IsType<MobileAppControllerConfigProvider>(actual);
+        }
+
+        [Fact]
+        public void GetMobileAppControllerNames_ReturnsCorrectControllers()
+        {
+            // Arrange
+            var typeList = new[]
+            {
+                typeof(MobileAppController),
+                typeof(ApiController),
+                typeof(DerivedMobileAppControllerController),
+                typeof(NormalApiController)
+            };
+
+            HttpConfiguration config = new HttpConfiguration();
+            IAssembliesResolver assemblyResolver = config.Services.GetAssembliesResolver();
+            Mock<IHttpControllerTypeResolver> typeResolverMock = new Mock<IHttpControllerTypeResolver>();
+            typeResolverMock.Setup(m => m.GetControllerTypes(assemblyResolver)).Returns(typeList);
+
+            config.Services.Replace(typeof(IHttpControllerTypeResolver), typeResolverMock.Object);
+
+            // Act
+            var names = config.GetMobileAppControllerNames();
+
+            // Assert
+            Assert.Equal(new[] { "MobileApp", "DerivedMobileAppController" }, names);
+        }
+
+        [MobileAppController]
+        private class MobileAppController : ApiController
+        {
+        }
+
+        private class DerivedMobileAppControllerAttribute : MobileAppControllerAttribute
+        {
+        }
+
+        [DerivedMobileAppController]
+        private class DerivedMobileAppControllerController : ApiController
+        {
+        }
+
+        private class NormalApiController : ApiController
+        {
         }
     }
 }

--- a/test/Microsoft.Azure.Mobile.Server.Test/Microsoft.Azure.Mobile.Server.Test.csproj
+++ b/test/Microsoft.Azure.Mobile.Server.Test/Microsoft.Azure.Mobile.Server.Test.csproj
@@ -207,7 +207,9 @@
     <Compile Include="Cache\CachePolicyProviderTests.cs" />
     <Compile Include="Cache\CachePolicyTests.cs" />
     <Compile Include="Config\AppConfigurationTests.cs" />
+    <Compile Include="Config\MobileAppConfigurationTests.cs" />
     <Compile Include="Config\MobileAppControllerAttributeTests.cs" />
+    <Compile Include="Config\MobileAppControllerConfigProviderTests.cs" />
     <Compile Include="Content\StaticHtmlActionResultTests.cs" />
     <Compile Include="Controllers\MobileAppControllerCacheTests.cs" />
     <Compile Include="Controllers\CorsControllerTest.cs" />


### PR DESCRIPTION
This commit includes the following:

- Resolution for #40. Extensions to `MobileAppConfiguration` can now add route exclusion strings that will be taken into account when mapping the /api route. Any strings added to the list will be a part of the `IHttpRouteConstraint`.
- Resolution for #48. Added `IMobileAppControllerConfigProvider` that can be used to change the settings for all Mobile App Controllers, including TableControllers.
- New tests to cover the gaps that led to the issues above.
- Misc Code Analysis improvements.
- Misc documentation improvements. 