### PR TITLE
Fixed assertion in one of the test and optimized retrieval of authentication header

### DIFF
--- a/src/Microsoft.Azure.Mobile.Server.Authentication/Middleware/AppServiceAuthenticationHandler.cs
+++ b/src/Microsoft.Azure.Mobile.Server.Authentication/Middleware/AppServiceAuthenticationHandler.cs
@@ -89,10 +89,7 @@ namespace Microsoft.Azure.Mobile.Server.Authentication
                 identity = new ClaimsIdentity();
             }
 
-            return new AuthenticationTicket(identity, new AuthenticationProperties()
-            {
-                
-            });
+            return new AuthenticationTicket(identity, null);
         }
 
         /// <summary>

--- a/src/Microsoft.Azure.Mobile.Server.Authentication/Middleware/AppServiceAuthenticationHandler.cs
+++ b/src/Microsoft.Azure.Mobile.Server.Authentication/Middleware/AppServiceAuthenticationHandler.cs
@@ -89,7 +89,10 @@ namespace Microsoft.Azure.Mobile.Server.Authentication
                 identity = new ClaimsIdentity();
             }
 
-            return new AuthenticationTicket(identity, null);
+            return new AuthenticationTicket(identity, new AuthenticationProperties()
+            {
+                
+            });
         }
 
         /// <summary>
@@ -112,14 +115,12 @@ namespace Microsoft.Azure.Mobile.Server.Authentication
             {
                 throw new ArgumentNullException("options");
             }
-
-            bool tokenHeaderExists = request.Headers.ContainsKey(AuthenticationHeaderName);
-            if (!tokenHeaderExists)
+            string[] tokenFromHeaderCollection;            
+            if (!request.Headers.TryGetValue(AuthenticationHeaderName,out tokenFromHeaderCollection))
             {
                 return null;
             }
-
-            string tokenFromHeader = request.Headers.Get(AuthenticationHeaderName);
+            string tokenFromHeader = tokenFromHeaderCollection[0];            
 
             // Attempt to parse and validate the token from header
             ClaimsPrincipal claimsPrincipalFromToken;

--- a/test/Microsoft.Azure.Mobile.Server.Login.Test/AppServiceLoginHandlerTests.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Login.Test/AppServiceLoginHandlerTests.cs
@@ -3,7 +3,6 @@
 // ----------------------------------------------------------------------------
 
 using System;
-using System.Diagnostics;
 using System.IdentityModel.Tokens;
 using System.Linq;
 using System.Security.Claims;

--- a/test/Microsoft.Azure.Mobile.Server.Login.Test/AppServiceLoginHandlerTests.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Login.Test/AppServiceLoginHandlerTests.cs
@@ -3,6 +3,7 @@
 // ----------------------------------------------------------------------------
 
 using System;
+using System.Diagnostics;
 using System.IdentityModel.Tokens;
 using System.Linq;
 using System.Security.Claims;
@@ -26,12 +27,12 @@ namespace Microsoft.Azure.Mobile.Server.Login.Test
                 new Claim(JwtRegisteredClaimNames.Sub, UserId),
                 new Claim("custom_claim_1", "CustomClaimValue1"),
                 new Claim("custom_claim_2", "CustomClaimValue2")
-            };
+            };            
             JwtSecurityToken token = AppServiceLoginHandler.CreateToken(claims, SigningKey, Audience, Issuer, TimeSpan.FromDays(10));
-
-            Assert.Equal(8, token.Claims.Count());
-
-            Assert.Equal(10, (token.ValidTo - DateTime.Now).Days);
+            
+            Assert.Equal(8, token.Claims.Count());    
+                    
+            Assert.Equal(10, (token.ValidTo - token.ValidFrom).Days);
             Assert.NotNull(token.Payload.Exp);
             Assert.Equal("CustomClaimValue1", token.Claims.Single(p => p.Type == "custom_claim_1").Value);
             Assert.Equal("CustomClaimValue2", token.Claims.Single(p => p.Type == "custom_claim_2").Value);


### PR DESCRIPTION
Fixed an assertion in AppServiceLoginHandlerTests/CreateToken_CreatesExpectedToken for validating timespan between issue and expiration of token. 

Optimized retrieval of authentication header from header with single call to TryGetValue.