### PR TITLE
removing oauth parameters from request sent to App Service Auth

### DIFF
--- a/src/Microsoft.Azure.Mobile.Server.Swagger/Swagger/swagger-oauth.js
+++ b/src/Microsoft.Azure.Mobile.Server.Swagger/Swagger/swagger-oauth.js
@@ -162,12 +162,13 @@ function handleLogin() {
 
         redirect_uri = redirectUrl;
 
+        // <AzureMobile>
+        /*
         url += '&realm=' + encodeURIComponent(realm);
         url += '&client_id=' + encodeURIComponent(clientId);
         url += '&scope=' + encodeURIComponent(scopes.join(scopeSeparator));
         url += '&state=' + encodeURIComponent(state);
-
-        // <AzureMobile>
+        */
         url += '&post_login_redirect_url=' + encodeURIComponent(redirectUrl);
         url += '&session_mode=token';
         // </AzureMobile>


### PR DESCRIPTION
This caused some providers to not login properly from Swagger (MS, Google didn't work but others did). Issue was that we were sending an empty scope which App Service Auth passed along rather than using the server-side-specified scopes. Some providers could handle empty scopes and others couldn't. We should just leave all that off and let the server handle it.