### PR TITLE
Fix KeyNotFound exception in StorageDomainManager

### DIFF
--- a/src/Microsoft.Azure.Mobile.Server.Storage/StorageDomainManager.cs
+++ b/src/Microsoft.Azure.Mobile.Server.Storage/StorageDomainManager.cs
@@ -303,18 +303,24 @@ namespace Microsoft.Azure.Mobile.Server
 
         private IEdmModel GetEdmModel()
         {
+            object modelFromDescriptor = null;
             var actionDescriptor = this.Request.GetActionDescriptor();
-            IEdmModel model = actionDescriptor == null ? null : (IEdmModel)actionDescriptor.Properties[ModelKeyPrefix + typeof(TData).FullName];
-            if (model != null)
+
+            if (actionDescriptor != null)
             {
-                return model;
+                actionDescriptor.Properties.TryGetValue(ModelKeyPrefix + typeof(TData).FullName, out modelFromDescriptor);
+            }
+
+            var edmModel = modelFromDescriptor as IEdmModel;
+            if (edmModel != null)
+            {
+                return edmModel;
             }
 
             var builder = new ODataConventionModelBuilder();
             builder.EntitySet<TData>(this.TableName);
-            model = builder.GetEdmModel();
 
-            return model;
+            return builder.GetEdmModel();
         }
 
         public override async Task<SingleResult<TData>> LookupAsync(string id)


### PR DESCRIPTION
I hit this bug locally and deemed that it should be fixed 😃

The StorageDomainManager does not check if the key on the ActionDescriptor Properties exists before attempting to access it. As the code already has handling for a null model, it seems that it was the intention that the model may not exist on the Action Descriptor, so we now do our best to pull the model from the action descriptor if possible and fall back to the ODataConventionModelBuilder if necessary.

The code in QueryAsync calling GetEdmModel seemed a bit odd/suspicious, as it rebuilds the ODataQueryOptions rather than using those passed into the function (despite throwing an ArgumentException on null), but I decided that this fix was probably necessary regardless.
