### PR TITLE
Add hook for custom complex entity relationships

### DIFF
--- a/src/Microsoft.Azure.Mobile.Server.Entity/MappedEntityDomainManager.cs
+++ b/src/Microsoft.Azure.Mobile.Server.Entity/MappedEntityDomainManager.cs
@@ -237,7 +237,7 @@ namespace Microsoft.Azure.Mobile.Server
             }
 
             patch.Patch(data);
-            model = MapDtoToEntity(data, model);
+            MapDtoToEntity(data, model);
 
             await this.SubmitChangesAsync();
 

--- a/src/Microsoft.Azure.Mobile.Server.Entity/MappedEntityDomainManager.cs
+++ b/src/Microsoft.Azure.Mobile.Server.Entity/MappedEntityDomainManager.cs
@@ -414,7 +414,7 @@ namespace Microsoft.Azure.Mobile.Server
     
     
         /// <summary>
-        /// Maps from a DTO to an entity.
+        /// Maps from a DTO to an existing entity.
         /// </summary>
         /// <remarks>
         /// This default implementation relies on the existence of a suitable
@@ -422,10 +422,9 @@ namespace Microsoft.Azure.Mobile.Server
         /// custom mapping of complex entity relationships.
         /// </remarks>
         /// <param name="dto">The source DTO.</param>
-        /// <param name="entity">An existing destination entity.</param>
-        /// <returns>The updated existing destination entity.</returns>
-        protected virtual TModel MapDtoToEntity(TData dto, TModel entity) {
-            return Mapper.Map(dto, entity);
+        /// <param name="entity">An existing destination entity, which will be updated.</param>
+        protected virtual void MapDtoToEntity(TData dto, TModel entity) {
+            Mapper.Map(dto, entity);
         }
 
         

--- a/src/Microsoft.Azure.Mobile.Server.Entity/MappedEntityDomainManager.cs
+++ b/src/Microsoft.Azure.Mobile.Server.Entity/MappedEntityDomainManager.cs
@@ -408,7 +408,7 @@ namespace Microsoft.Azure.Mobile.Server
         /// </remarks>
         /// <param name="dto">The source DTO.</param>
         /// <returns>The destination entity.</returns>
-        protected virtual TEntity MapDtoToEntity(TData dto) {
+        protected virtual TModel MapDtoToEntity(TData dto) {
             return Mapper.Map<TData, TModel>(dto);
         }
     


### PR DESCRIPTION
Allows a subclass to call out into a service to perform custom complex entity relationships - i.e. a custom mapping for many:many scenarios.

[Refer to issue here](https://github.com/Azure/azure-mobile-apps-net-server/issues/159).
