### PR TITLE
Removing signing key - overridden in portal anyways

### DIFF
--- a/test/Microsoft.Azure.Mobile.Server.Storage.Test/App.config
+++ b/test/Microsoft.Azure.Mobile.Server.Storage.Test/App.config
@@ -13,7 +13,7 @@
     <add name="MS_StorageConnectionString" connectionString="UseDevelopmentStorage=true" />
   </connectionStrings>
   <appSettings>
-    <add key="MS_SigningKey" value="bMyklciUDJxqSxtSiJlSusbiZrMnuG99" />
+    <add key="MS_SigningKey" value="Overridden by portal settings" />
     <add key="MS_SkipVersionCheck" value="true" />
     <add key="xunit.methodDisplay" value="method" />
     <add key="xunit.parallelizeTestCollections" value="false" />


### PR DESCRIPTION
This was getting caught by cred scanner so we need to remove it.