### PR TITLE
Added dependency versioning for System.IdentityModel.Tokens.Jwt

### DIFF
--- a/src/Microsoft.Azure.Mobile.Server.Authentication/Microsoft.Azure.Mobile.Server.Authentication.nuspec
+++ b/src/Microsoft.Azure.Mobile.Server.Authentication/Microsoft.Azure.Mobile.Server.Authentication.nuspec
@@ -6,7 +6,7 @@
     <title>Azure Mobile .NET Server Authentication</title>
     <authors>Microsoft</authors>
     <owners>Microsoft azure-sdk</owners>
-    <licenseUrl>http://go.microsoft.com/fwlink/?LinkID=331327</licenseUrl>    
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkID=331327</licenseUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</iconUrl>
     <projectUrl>https://github.com/azure/azure-mobile-apps-net-server</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -21,4 +21,7 @@
   <files>
     <file src="**\Microsoft.Azure.Mobile.Server.Authentication.resources.dll" target="lib\net46" />
   </files>
+  <dependencies>
+    <dependency id="System.IdentityModel.Tokens.Jwt" version="(4.0.3,5.0)" />
+  </dependencies>
 </package>

--- a/src/Microsoft.Azure.Mobile.Server.Login/Microsoft.Azure.Mobile.Server.Login.nuspec
+++ b/src/Microsoft.Azure.Mobile.Server.Login/Microsoft.Azure.Mobile.Server.Login.nuspec
@@ -6,7 +6,7 @@
     <title>Microsoft Azure Mobile App .NET Server Login Extension</title>
     <authors>Microsoft</authors>
     <owners>Microsoft azure-sdk</owners>
-    <licenseUrl>http://go.microsoft.com/fwlink/?LinkID=331327</licenseUrl>    
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkID=331327</licenseUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</iconUrl>
     <projectUrl>https://github.com/azure/azure-mobile-apps-net-server</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -18,4 +18,7 @@
   <files>
     <file src="**\Microsoft.Azure.Mobile.Server.Login.resources.dll" target="lib\net46" />
   </files>
+  <dependencies>
+    <dependency id="System.IdentityModel.Tokens.Jwt" version="(4.0.3,5.0)" />
+  </dependencies>
 </package>


### PR DESCRIPTION
We are always getting complaints that we should not allow updates to System.IdentityModel.Tokens.Jwt - this patch provides appropriate dependency checking.  See https://docs.microsoft.com/en-us/nuget/create-packages/dependency-versions for info on dependency checking.